### PR TITLE
Support streaming output in copilot-chat-shell-maker

### DIFF
--- a/copilot-chat-shell-maker.el
+++ b/copilot-chat-shell-maker.el
@@ -38,7 +38,6 @@
   (make-shell-maker-config
     :name "Copilot-Chat-shell"
     :execute-command 'copilot-chat-shell-cb))
-(defvar copilot-chat-shell-maker-answer nil)
 
 
 (defun copilot-chat-shell-maker-ask-region(prompt)
@@ -65,15 +64,14 @@
   (switch-to-buffer (copilot-chat-get-shell-buffer)))
 
 (defun copilot-chat-shell-cb-prompt (callback error-callback content)
-  (if (string= content copilot-chat-magic)
-      (with-current-buffer (copilot-chat-get-shell-buffer)
-        (funcall callback copilot-chat-shell-maker-answer nil)
-		(setq copilot-chat-shell-maker-answer nil))
-    (setq copilot-chat-shell-maker-answer (concat copilot-chat-shell-maker-answer content))))
+  (with-current-buffer (copilot-chat-get-shell-buffer)
+    (if (string= content copilot-chat-magic)
+        (funcall callback "" nil) ;; all done, lets close it off (partial = nil)
+      (funcall callback content t)))) ;; still going (partial = t)
+
 
 (defun copilot-chat-shell-cb (command _history callback error-callback)
-  (setq copilot-chat-shell-cb-fn (apply-partially 'copilot-chat-shell-cb-prompt callback error-callback)
-        copilot-chat-shell-maker-answer nil)
+  (setq copilot-chat-shell-cb-fn (apply-partially 'copilot-chat-shell-cb-prompt callback error-callback))
   (copilot-chat-ask command copilot-chat-shell-cb-fn))
 
 


### PR DESCRIPTION
This tweaks `copilot-chat-shell-cb-prompt` to support streaming directly, rather than buffering internally to the (now removed) `copilot-chat-shell-maker-answer` variable.

In particular, the `shell-maker` `execute-command` is called with a lambda that accepts two arguments, `(lambda (response partial) ...)`. If `partial` is `t`, it seems to be treated as a streaming response and appended to the content, without starting a new prompt.

Reference: https://github.com/xenodium/chatgpt-shell/blob/f7b1f1e4b8a07c97deba92d9a23145d192ce715f/shell-maker.el#L632

Demo: 

https://github.com/user-attachments/assets/6fbe5657-d1f5-4ce9-933a-0cbd38d61dfb


Thanks for publishing this library, very nice!