### PR TITLE
Prepare Copilot Chat buffers in `copilot-chat-ask-region`

### DIFF
--- a/copilot-chat-copilot.el
+++ b/copilot-chat-copilot.el
@@ -53,7 +53,7 @@
     (review . "Please review the following code:\n")
     (doc . "Please write documentation for the following code:\n")
     (fix . "There is a problem in this code. Please rewrite the code to show it with the bug fixed.\n")
-    (optimize . "Please optimize the following code to improve performance and readablilty:\n")
+    (optimize . "Please optimize the following code to improve performance and readability:\n")
     (test . "Please generate tests for the following code:\n"))
     "Copilot chat predefined prompts")
 

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -142,6 +142,7 @@
 
 (defun copilot-chat-ask-region(prompt)
   (let ((code (buffer-substring-no-properties (region-beginning) (region-end))))
+    (copilot-chat--prepare-buffers)
     (with-current-buffer copilot-chat-prompt-buffer
       (erase-buffer)
       (insert (concat (cdr (assoc prompt copilot-chat-prompts)) code)))
@@ -218,8 +219,8 @@
       (copilot-chat-list-mode))
     (switch-to-buffer buffer)))
 
-(defun copilot-chat-display ()
-  (interactive)
+(defun copilot-chat--prepare-buffers()
+  "Create the copilot-chat-buffer and copilot-chat-prompt-buffer."
   (unless (copilot-chat-ready-p)
     (copilot-chat-reset))
   (let ((chat-buffer (get-buffer-create copilot-chat-buffer))
@@ -228,6 +229,13 @@
       (copilot-chat-mode))
     (with-current-buffer prompt-buffer
       (copilot-chat-prompt-mode))
+  (list chat-buffer prompt-buffer)))
+
+(defun copilot-chat-display ()
+  (interactive)
+  (let* ((buffers (copilot-chat--prepare-buffers))
+         (chat-buffer (car buffers))
+         (prompt-buffer (cdr buffers)))
     (switch-to-buffer chat-buffer)
     (let ((split-window-preferred-function nil)
           (split-height-threshold nil)


### PR DESCRIPTION
Currently, running `copilot-chat-doc` or similar functions before `copilot-chat-display` results in a "No buffer named *Copilot-chat-prompt*" error. This commit extracts the buffer preparation segment from `copilot-chat-display` into a separate function, which is then invoked within `copilot-chat-ask-region`.

In addition, this commit fixes a typo in `copilot-chat-prompts`