### PR TITLE
Use gpt-4o model

### DIFF
--- a/copilot-chat-copilot.el
+++ b/copilot-chat-copilot.el
@@ -213,7 +213,7 @@
 
     (json-encode `(("messages" . ,(vconcat messages))
                    ("top_p" . 1)
-                   ("model" . "gpt-4")
+                   ("model" . "gpt-4o-2024-05-13")
                    ("stream" . t)
                    ("n" . 1)
                    ("intent" . t)


### PR DESCRIPTION
This upgrades from GPT-4 model to GPT-4o, mimicking https://github.com/CopilotC-Nvim/CopilotChat.nvim/pull/377

The new model appears to be noticeably quicker to provide responses, but hard to tell for sure!

Announcement: https://github.blog/changelog/2024-07-31-github-copilot-chat-and-pull-request-summaries-are-now-powered-by-gpt-4o/