### PR TITLE
Custom prompts for various commands, such as `copilot-chat-explain`, `-review` and others

### DIFF
--- a/copilot-chat-copilot.el
+++ b/copilot-chat-copilot.el
@@ -48,15 +48,6 @@
 
 
 ;; constants
-(defconst copilot-chat--prompts
-  '((explain . "Please write an explanation for the following code:\n")
-    (review . "Please review the following code:\n")
-    (doc . "Please write documentation for the following code:\n")
-    (fix . "There is a problem in this code. Please rewrite the code to show it with the bug fixed.\n")
-    (optimize . "Please optimize the following code to improve performance and readability:\n")
-    (test . "Please generate tests for the following code:\n"))
-    "Copilot chat predefined prompts.")
-
 (defconst copilot-chat--magic "#cc#done#!$")
 
 
@@ -78,6 +69,37 @@
   "The prompt to use for Copilot chat."
   :type 'string
   :group 'copilot-chat)
+
+(defcustom copilot-chat--prompt-explain "Please write an explanation for the following code:\n"
+  "The prompt used by copilot-chat-explain"
+  :type 'string
+  :group 'copilot-chat)
+
+(defcustom copilot-chat--prompt-review "Please review the following code:\n"
+  "The prompt used by copilot-chat-review"
+  :type 'string
+  :group 'copilot-chat)
+
+(defcustom copilot-chat--prompt-doc "Please write documentation for the following code:\n"
+  "The prompt used by copilot-chat-doc"
+  :type 'string
+  :group 'copilot-chat)
+
+(defcustom copilot-chat--prompt-fix "There is a problem in this code. Please rewrite the code to show it with the bug fixed.\n"
+  "The prompt used by copilot-chat-fix"
+  :type 'string
+  :group 'copilot-chat)
+
+(defcustom copilot-chat--prompt-optimize "Please optimize the following code to improve performance and readability:\n"
+  "The prompt used by copilot-chat-optimize"
+  :type 'string
+  :group 'copilot-chat)
+
+(defcustom copilot-chat--prompt-test "Please generate tests for the following code:\n"
+  "The prompt used by copilot-chat-test"
+  :type 'string
+  :group 'copilot-chat)
+
 (defcustom copilot-chat-use-curl t
   "If set to t, `copilot-chat' will use curl instead of url Emacs api."
   :type 'boolean
@@ -106,7 +128,16 @@
 (defvar copilot-chat--curl-file nil)
 
 
-;; Fonctions
+;; Functions
+(defun copilot-chat--prompts ()
+  "Return assoc list of promts for each command"
+  `((explain . ,copilot-chat--prompt-explain)
+    (review . ,copilot-chat--prompt-review)
+    (doc . ,copilot-chat--prompt-doc)
+    (fix . ,copilot-chat--prompt-fix)
+    (optimize . ,copilot-chat--prompt-optimize)
+    (test . ,copilot-chat--prompt-test)))
+
 (defun copilot-chat--uuid ()
   "Generate a UUID."
   (format "%04x%04x-%04x-4%03x-%04x-%04x%04x%04x"

--- a/copilot-chat-copilot.el
+++ b/copilot-chat-copilot.el
@@ -70,32 +70,32 @@
   :type 'string
   :group 'copilot-chat)
 
-(defcustom copilot-chat--prompt-explain "Please write an explanation for the following code:\n"
+(defcustom copilot-chat-prompt-explain "Please write an explanation for the following code:\n"
   "The prompt used by copilot-chat-explain"
   :type 'string
   :group 'copilot-chat)
 
-(defcustom copilot-chat--prompt-review "Please review the following code:\n"
+(defcustom copilot-chat-prompt-review "Please review the following code:\n"
   "The prompt used by copilot-chat-review"
   :type 'string
   :group 'copilot-chat)
 
-(defcustom copilot-chat--prompt-doc "Please write documentation for the following code:\n"
+(defcustom copilot-chat-prompt-doc "Please write documentation for the following code:\n"
   "The prompt used by copilot-chat-doc"
   :type 'string
   :group 'copilot-chat)
 
-(defcustom copilot-chat--prompt-fix "There is a problem in this code. Please rewrite the code to show it with the bug fixed.\n"
+(defcustom copilot-chat-prompt-fix "There is a problem in this code. Please rewrite the code to show it with the bug fixed.\n"
   "The prompt used by copilot-chat-fix"
   :type 'string
   :group 'copilot-chat)
 
-(defcustom copilot-chat--prompt-optimize "Please optimize the following code to improve performance and readability:\n"
+(defcustom copilot-chat-prompt-optimize "Please optimize the following code to improve performance and readability:\n"
   "The prompt used by copilot-chat-optimize"
   :type 'string
   :group 'copilot-chat)
 
-(defcustom copilot-chat--prompt-test "Please generate tests for the following code:\n"
+(defcustom copilot-chat-prompt-test "Please generate tests for the following code:\n"
   "The prompt used by copilot-chat-test"
   :type 'string
   :group 'copilot-chat)
@@ -131,12 +131,12 @@
 ;; Functions
 (defun copilot-chat--prompts ()
   "Return assoc list of promts for each command"
-  `((explain . ,copilot-chat--prompt-explain)
-    (review . ,copilot-chat--prompt-review)
-    (doc . ,copilot-chat--prompt-doc)
-    (fix . ,copilot-chat--prompt-fix)
-    (optimize . ,copilot-chat--prompt-optimize)
-    (test . ,copilot-chat--prompt-test)))
+  `((explain . ,copilot-chat-prompt-explain)
+    (review . ,copilot-chat-prompt-review)
+    (doc . ,copilot-chat-prompt-doc)
+    (fix . ,copilot-chat-prompt-fix)
+    (optimize . ,copilot-chat-prompt-optimize)
+    (test . ,copilot-chat-prompt-test)))
 
 (defun copilot-chat--uuid ()
   "Generate a UUID."

--- a/copilot-chat-shell-maker.el
+++ b/copilot-chat-shell-maker.el
@@ -57,7 +57,7 @@
 (defun copilot-chat--shell-maker-ask-region(prompt)
   (let ((code (buffer-substring-no-properties (region-beginning) (region-end))))
     (with-current-buffer (copilot-chat--get-shell-buffer)
-      (insert (concat (cdr (assoc prompt copilot-chat--prompts)) code))
+      (insert (concat (cdr (assoc prompt (copilot-chat--prompts))) code))
       (shell-maker-submit))))
 
 

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -174,7 +174,7 @@
     (copilot-chat--prepare-buffers)
     (with-current-buffer copilot-chat-prompt-buffer
       (erase-buffer)
-      (insert (concat (cdr (assoc prompt copilot-chat--prompts)) code)))
+      (insert (concat (cdr (assoc prompt (copilot-chat--prompts))) code)))
     (copilot-chat-prompt-send)))
 
 ;;;###autoload


### PR DESCRIPTION
## About

I want to use customized prompt on `copilot-chat-review`, `copilit-chat-explain` commands.
So I tried to change to `defcustom` instead of `defconst`.

## Usage

In `.emacs.d/init.el`:

```lisp
(setopt copilot-chat--prompt-review "MY OWN PROMPT")
```