### PR TITLE
copilot-chat-curl-program: search PATH

### DIFF
--- a/copilot-chat-curl.el
+++ b/copilot-chat-curl.el
@@ -33,7 +33,7 @@
 (defvar copilot-chat--curl-current-data nil)
 
 ;; customs
-(defcustom copilot-chat-curl-program "/usr/bin/curl"
+(defcustom copilot-chat-curl-program "curl"
   "Curl program to use if `copilot-chat-use-curl' is set."
   :type 'string
   :group 'copilot-chat)


### PR DESCRIPTION
On systems like NixOS, paths like /usr/bin don't really exist. It's expected that scripts will call applications by name and use PATH resolution to get at the actual binary. By rooting curl at /usr/bin/curl, this method fails on NixOS.

This also would have problems on other systems like macOS or Windows where /usr/bin might not be where the desired curl is located.

Switch to using the plain value "curl" so that PATH resolution is used normally.