### PR TITLE
Adding link to copilot.el project in README for code completion

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -133,3 +133,5 @@ Warning : key bindings have changed since Melpa integration needs to avoid `C-c
 This plugin is unofficial and based on Copilot Chat for neovim repository: https://github.com/CopilotC-Nvim/CopilotChat.nvim
 
 The prompt for git commit messages comes from [gpt-commit](https://github.com/ywkim/gpt-commit).
+
+For github copilot code completion in emacs, checkout [copilot.el](https://github.com/copilot-emacs/copilot.el)


### PR DESCRIPTION
Adding the link to the project. It is a complimentary for github copilot inside emacs.