### PR TITLE
feat: Add couple of shortcuts for content "under point"

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -77,7 +77,7 @@ Selected buffers will be sent with each prompt until you remove them.
 - `(copilot-chat-optimize)` ask copilot to optimize selected code.
 - `(copilot-chat-test)` ask copilot to write tests for selected code.
 - `(copilot-chat-custom-prompt-selection)` ask for a prompt in minibuffer and pastes selection after it before sending it to copilot.
-- `(copilot-chat-explain-defun)` ask copilot to explain currnet function under point.
+- `(copilot-chat-explain-defun)` ask copilot to explain current function under point.
 - `(copilot-chat-custom-prompt-function)` ask copilot to apply a custom prompt to the function body under point. Eg. instruct on how to refactor the function.
 - `(copilot-chat-review-whole-buffer)` ask copilot to review the current whole buffer. It can be used to review the full class, or, review the magit diff for my change, or other people's change.
 - `(copilot-chat-switch-to-buffer)` switch to Copilot Chat buffer, side by side with the current code editing buffer.

--- a/Readme.md
+++ b/Readme.md
@@ -77,6 +77,10 @@ Selected buffers will be sent with each prompt until you remove them.
 - `(copilot-chat-optimize)` ask copilot to optimize selected code.
 - `(copilot-chat-test)` ask copilot to write tests for selected code.
 - `(copilot-chat-custom-prompt-selection)` ask for a prompt in minibuffer and pastes selection after it before sending it to copilot.
+- `(copilot-chat-explain-defun)` ask copilot to explain currnet function under point.
+- `(copilot-chat-custom-prompt-function)` ask copilot to apply a custom prompt to the function body under point. Eg. instruct on how to refactor the function.
+- `(copilot-chat-review-whole-buffer)` ask copilot to review the current whole buffer. It can be used to review the full class, or, review the magit diff for my change, or other people's change.
+- `(copilot-chat-switch-to-buffer)` switch to Copilot Chat buffer, side by side with the current code editing buffer.
 - `(copilot-chat-add-current-buffer)` add current buffer to copilot chat. Its content will be sent with every request.
 - `(copilot-chat-del-current-buffer)` remove current buffer.
 - `(copilot-chat-list)` open buffer list.

--- a/copilot-chat-shell-maker.el
+++ b/copilot-chat-shell-maker.el
@@ -154,6 +154,7 @@ Argument ERROR-CALLBACK is the error callback function to call."
   "Clean the copilot chat shell-maker frontend."
   (advice-remove 'copilot-chat--ask-region #'copilot-chat--shell-maker-ask-region)
   (advice-remove 'copilot-chat-custom-prompt-selection #'copilot-chat-shell-maker-custom-prompt-selection)
+  (advice-remove 'copilot-chat-explain-symbol-at-line #'copilot-chat-explain-symbol-at-line)
   (advice-remove 'copilot-chat-display #'copilot-chat-shell-maker-display)
   (advice-remove 'copilot-chat--clean #'copilot-chat--shell-maker-clean))
 
@@ -163,6 +164,7 @@ Argument ERROR-CALLBACK is the error callback function to call."
 
   (advice-add 'copilot-chat--ask-region :override #'copilot-chat--shell-maker-ask-region)
   (advice-add 'copilot-chat-custom-prompt-selection :override #'copilot-chat-shell-maker-custom-prompt-selection)
+  (advice-add 'copilot-chat-explain-symbol-at-line :override #'copilot-chat-explain-symbol-at-line)
   (advice-add 'copilot-chat-display :override #'copilot-chat-shell-maker-display)
   (advice-add 'copilot-chat--clean :after #'copilot-chat--shell-maker-clean))
 

--- a/copilot-chat-shell-maker.el
+++ b/copilot-chat-shell-maker.el
@@ -154,7 +154,6 @@ Argument ERROR-CALLBACK is the error callback function to call."
   "Clean the copilot chat shell-maker frontend."
   (advice-remove 'copilot-chat--ask-region #'copilot-chat--shell-maker-ask-region)
   (advice-remove 'copilot-chat-custom-prompt-selection #'copilot-chat-shell-maker-custom-prompt-selection)
-  (advice-remove 'copilot-chat-explain-symbol-at-line #'copilot-chat-explain-symbol-at-line)
   (advice-remove 'copilot-chat-display #'copilot-chat-shell-maker-display)
   (advice-remove 'copilot-chat--clean #'copilot-chat--shell-maker-clean))
 
@@ -164,7 +163,6 @@ Argument ERROR-CALLBACK is the error callback function to call."
 
   (advice-add 'copilot-chat--ask-region :override #'copilot-chat--shell-maker-ask-region)
   (advice-add 'copilot-chat-custom-prompt-selection :override #'copilot-chat-shell-maker-custom-prompt-selection)
-  (advice-add 'copilot-chat-explain-symbol-at-line :override #'copilot-chat-explain-symbol-at-line)
   (advice-add 'copilot-chat-display :override #'copilot-chat-shell-maker-display)
   (advice-add 'copilot-chat--clean :after #'copilot-chat--shell-maker-clean))
 

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -274,9 +274,29 @@ Argument PROMPT is the prompt to send to Copilot."
       (insert formatted-prompt))
     (copilot-chat-prompt-send)))
 
+(defun copilot-chat--explain-symbol-prompt(symbol line)
+  "Returns explain symbol prompt."
+  (let ((lang (replace-regexp-in-string
+               "-mode$" ""
+               (symbol-name major-mode))))
+    (format "In %s programming language, please explain what '%s' means in the context of this code line:\n%s" 
+            lang symbol line)))
+
+(defun copilot-chat--explain-symbol-at-line(prompt)
+  "Ask Copilot to explain symbol under point.
+Code line is given as background info.
+Frontend may override this function.
+PROMPT is the prompt to send to copilot"
+    (copilot-chat--prepare-buffers)
+    (with-current-buffer copilot-chat--prompt-buffer
+      (erase-buffer)
+      (insert prompt))
+    (copilot-chat-prompt-send))
+
 ;;;###autoload
 (defun copilot-chat-explain-symbol-at-line()
-  "Ask Copilot to explain symbol under point, given the code line as background info."
+  "Ask Copilot to explain symbol under point.
+Code line is given as background info."
   (interactive)
   (unless (copilot-chat--ready-p)
     (copilot-chat-reset))
@@ -284,16 +304,8 @@ Argument PROMPT is the prompt to send to Copilot."
          (line (buffer-substring-no-properties 
                 (line-beginning-position)
                 (line-end-position)))
-         (lang (replace-regexp-in-string
-                "-mode$" ""
-                (symbol-name major-mode)))
-         (prompt (format "In %s programming language, please explain what '%s' means in the context of this code line:\n%s" 
-                        lang symbol line)))
-    (copilot-chat--prepare-buffers)
-    (with-current-buffer copilot-chat--prompt-buffer
-      (erase-buffer)
-      (insert prompt))
-    (copilot-chat-prompt-send)))
+         (prompt (copilot-chat--explain-symbol-prompt symbol line)))
+    (copilot-chat--explain-symbol-at-line prompt)))
 
 
 (defun copilot-chat ()

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -284,8 +284,11 @@ Argument PROMPT is the prompt to send to Copilot."
          (line (buffer-substring-no-properties 
                 (line-beginning-position)
                 (line-end-position)))
-         (prompt (format "Please explain what '%s' means in the context of this code line:\n%s" 
-                        symbol line)))
+         (lang (replace-regexp-in-string
+                "-mode$" ""
+                (symbol-name major-mode)))
+         (prompt (format "In %s programming language, please explain what '%s' means in the context of this code line:\n%s" 
+                        lang symbol line)))
     (copilot-chat--prepare-buffers)
     (with-current-buffer copilot-chat--prompt-buffer
       (erase-buffer)

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -274,29 +274,9 @@ Argument PROMPT is the prompt to send to Copilot."
       (insert formatted-prompt))
     (copilot-chat-prompt-send)))
 
-(defun copilot-chat--explain-symbol-prompt(symbol line)
-  "Returns explain symbol prompt."
-  (let ((lang (replace-regexp-in-string
-               "-mode$" ""
-               (symbol-name major-mode))))
-    (format "In %s programming language, please explain what '%s' means in the context of this code line:\n%s" 
-            lang symbol line)))
-
-(defun copilot-chat--explain-symbol-at-line(prompt)
-  "Ask Copilot to explain symbol under point.
-Code line is given as background info.
-Frontend may override this function.
-PROMPT is the prompt to send to copilot"
-    (copilot-chat--prepare-buffers)
-    (with-current-buffer copilot-chat--prompt-buffer
-      (erase-buffer)
-      (insert prompt))
-    (copilot-chat-prompt-send))
-
 ;;;###autoload
 (defun copilot-chat-explain-symbol-at-line()
-  "Ask Copilot to explain symbol under point.
-Code line is given as background info."
+  "Ask Copilot to explain symbol under point, given the code line as background info."
   (interactive)
   (unless (copilot-chat--ready-p)
     (copilot-chat-reset))
@@ -304,8 +284,16 @@ Code line is given as background info."
          (line (buffer-substring-no-properties 
                 (line-beginning-position)
                 (line-end-position)))
-         (prompt (copilot-chat--explain-symbol-prompt symbol line)))
-    (copilot-chat--explain-symbol-at-line prompt)))
+         (lang (replace-regexp-in-string
+                "-mode$" ""
+                (symbol-name major-mode)))
+         (prompt (format "In %s programming language, please explain what '%s' means in the context of this code line:\n%s" 
+                        lang symbol line)))
+    (copilot-chat--prepare-buffers)
+    (with-current-buffer copilot-chat--prompt-buffer
+      (erase-buffer)
+      (insert prompt))
+    (copilot-chat-prompt-send)))
 
 
 (defun copilot-chat ()

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -262,6 +262,14 @@ Argument PROMPT is the prompt to send to Copilot."
   (interactive)
   (copilot-chat--ask-region 'test))
 
+(defun copilot-chat--send-prompt (prompt)
+  "Helper function to prepare buffers and send PROMPT to Copilot."
+  (copilot-chat--prepare-buffers)
+  (with-current-buffer copilot-chat--prompt-buffer
+    (erase-buffer)
+    (insert prompt))
+  (copilot-chat-prompt-send))
+
 ;;;###autoload
 (defun copilot-chat-custom-prompt-selection()
   "Send to Copilot a custom prompt followed by the current selected code."
@@ -269,10 +277,7 @@ Argument PROMPT is the prompt to send to Copilot."
   (let* ((prompt (read-from-minibuffer "Copilot prompt: "))
          (code (buffer-substring-no-properties (region-beginning) (region-end)))
          (formatted-prompt (concat prompt "\n" code)))
-    (with-current-buffer copilot-chat--prompt-buffer
-      (erase-buffer)
-      (insert formatted-prompt))
-    (copilot-chat-prompt-send)))
+    (copilot-chat--send-prompt formatted-prompt)))
 
 ;;;###autoload
 (defun copilot-chat-explain-symbol-at-line()
@@ -289,11 +294,7 @@ Argument PROMPT is the prompt to send to Copilot."
                 (symbol-name major-mode)))
          (prompt (format "In %s programming language, please explain what '%s' means in the context of this code line:\n%s" 
                         lang symbol line)))
-    (copilot-chat--prepare-buffers)
-    (with-current-buffer copilot-chat--prompt-buffer
-      (erase-buffer)
-      (insert prompt))
-    (copilot-chat-prompt-send)))
+    (copilot-chat--send-prompt prompt)))
 
 
 (defun copilot-chat ()

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -274,6 +274,23 @@ Argument PROMPT is the prompt to send to Copilot."
       (insert formatted-prompt))
     (copilot-chat-prompt-send)))
 
+;;;###autoload
+(defun copilot-chat-explain-symbol-at-line()
+  "Ask Copilot to explain symbol under point, given the code line as background info."
+  (interactive)
+  (unless (copilot-chat--ready-p)
+    (copilot-chat-reset))
+  (let* ((symbol (thing-at-point 'symbol))
+         (line (buffer-substring-no-properties 
+                (line-beginning-position)
+                (line-end-position)))
+         (prompt (format "Please explain what '%s' means in the context of this code line:\n%s" 
+                        symbol line)))
+    (copilot-chat--prepare-buffers)
+    (with-current-buffer copilot-chat--prompt-buffer
+      (erase-buffer)
+      (insert prompt))
+    (copilot-chat-prompt-send)))
 
 
 (defun copilot-chat ()
@@ -423,8 +440,9 @@ Argument PROMPT is the prompt to send to Copilot."
                       nil
                       (if (= 0 copilot-chat--prompt-history-position)
                         ""
-                        (setq copilot-chat--prompt-history-position (1- copilot-chat--prompt-history-position))
-                        (nth copilot-chat--prompt-history-position copilot-chat--prompt-history))))))
+                        (progn
+                          (setq copilot-chat--prompt-history-position (1- copilot-chat--prompt-history-position))
+                          (nth copilot-chat--prompt-history-position copilot-chat--prompt-history)))))))
       (when prompt
         (erase-buffer)
         (insert prompt)))))

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -312,6 +312,40 @@ This function can be overriden by frontend."
     (copilot-chat--insert-and-send-prompt prompt)))
 
 ;;;###autoload
+(defun copilot-chat-explain-defun ()
+  "Mark current function definition and ask Copilot to explain it, then unmark."
+  (interactive)
+  (save-excursion
+    (mark-defun)
+    (copilot-chat-explain)
+    (deactivate-mark)))
+
+;;;###autoload
+(defun copilot-chat-custom-prompt-function ()
+  "Mark current function and ask copilot-chat with custom prompt."
+  (interactive)
+  (save-excursion
+    (mark-defun)
+    (copilot-chat-custom-prompt-selection)
+    (deactivate-mark)))
+
+;;;###autoload
+(defun copilot-chat-review-whole-buffer ()
+  "Mark whole buffer, ask Copilot to review it, then unmark.
+It can be used to review the magit diff for my change, or other people's"
+  (interactive)
+  (save-excursion
+    (mark-whole-buffer)
+    (copilot-chat-review)
+    (deactivate-mark)))
+
+;;;###autoload
+(defun copilot-chat-switch-to-buffer ()
+  "Switch to Copilot Chat buffer, side by side with the current code editing buffer."
+  (interactive)
+  (switch-to-buffer-other-window copilot-chat--buffer))
+
+;;;###autoload
 (defun copilot-chat-custom-prompt-selection()
   "Send to Copilot a custom prompt followed by the current selected code."
   (interactive)

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -343,6 +343,8 @@ It can be used to review the magit diff for my change, or other people's"
 (defun copilot-chat-switch-to-buffer ()
   "Switch to Copilot Chat buffer, side by side with the current code editing buffer."
   (interactive)
+  (unless (copilot-chat--ready-p)
+    (copilot-chat-reset))
   (switch-to-buffer-other-window copilot-chat--buffer))
 
 ;;;###autoload


### PR DESCRIPTION
- `(copilot-chat-explain-defun)` ask copilot to explain current function under point.
- `(copilot-chat-custom-prompt-function)` ask copilot to apply a custom prompt to the function body under point. Eg. instruct on how to refactor the function.
- `(copilot-chat-review-whole-buffer)` ask copilot to review the current whole buffer. It can be used to review the full class, or, review the magit diff for my change, or other people's change.
- `(copilot-chat-switch-to-buffer)` switch to Copilot Chat buffer, side by side with the current code editing buffer.