### PR TITLE
fix: Prefer to use slash commands

### DIFF
--- a/copilot-chat-copilot.el
+++ b/copilot-chat-copilot.el
@@ -32,32 +32,32 @@
 (require 'copilot-chat-curl)
 
 ;; customs
-(defcustom copilot-chat-prompt-explain "Please write an explanation for the following code:\n"
+(defcustom copilot-chat-prompt-explain "/explain\n"
   "The prompt used by `copilot-chat-explain'."
   :type 'string
   :group 'copilot-chat)
 
-(defcustom copilot-chat-prompt-review "Please review the following code:\n"
+(defcustom copilot-chat-prompt-review "Please review the following code.\n"
   "The prompt used by `copilot-chat-review'."
   :type 'string
   :group 'copilot-chat)
 
-(defcustom copilot-chat-prompt-doc "Please write documentation for the following code:\n"
+(defcustom copilot-chat-prompt-doc "/doc\n"
   "The prompt used by `copilot-chat-doc'."
   :type 'string
   :group 'copilot-chat)
 
-(defcustom copilot-chat-prompt-fix "There is a problem in this code. Please rewrite the code to show it with the bug fixed.\n"
+(defcustom copilot-chat-prompt-fix "/fix\n"
   "The prompt used by `copilot-chat-fix'."
   :type 'string
   :group 'copilot-chat)
 
-(defcustom copilot-chat-prompt-optimize "Please optimize the following code to improve performance and readability:\n"
+(defcustom copilot-chat-prompt-optimize "/optimize\n"
   "The prompt used by `copilot-chat-optimize'."
   :type 'string
   :group 'copilot-chat)
 
-(defcustom copilot-chat-prompt-test "Please generate tests for the following code:\n"
+(defcustom copilot-chat-prompt-test "/tests\n"
   "The prompt used by `copilot-chat-test'."
   :type 'string
   :group 'copilot-chat)


### PR DESCRIPTION
GitHub Copilot Chat comes with several pre-populated slash commands, and using the ones that are available will improve Copilot's efficiency and reliability.