### PR TITLE
feat: add current programming language as context, and a configurable suffix

### DIFF
--- a/copilot-chat-common.el
+++ b/copilot-chat-common.el
@@ -65,6 +65,12 @@
                  (const :tag "GPT-4o1-(preview)" "o1-preview"))
   :group 'copilot-chat)
 
+(defcustom copilot-chat-prompt-suffix nil
+  "Suffix to be added to the end of the prompt before sending to Copilot Chat. For Example: Reply in Chinese (or any other language)
+If nil, no suffix will be added."
+  :type 'string
+  :group 'copilot-chat)
+
 ;; structs
 (cl-defstruct copilot-chat
   ready

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -362,7 +362,7 @@ It can be used to review the magit diff for my change, or other people's"
   (interactive)
   (let* ((prompt "Question for copilot-chat: ")
          (input (read-string prompt nil 'copilot-chat--prompt-history)))
-    (copilot-chat--send-prompt input)
+    (copilot-chat--insert-and-send-prompt input)
     ))
 
 ;;;###autoload

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -280,9 +280,9 @@ Argument PROMPT is the prompt to send to Copilot."
   "Helper function to prepare buffers and send PROMPT to Copilot.
 This function may be overriden by frontend."
   (let* ((prompt-suffix (copilot-chat--build-prompt-suffix))
-           (final-prompt (if prompt-suffix
-                             (concat prompt "\n" prompt-suffix)
-                           prompt)))
+         (final-prompt (if prompt-suffix
+                           (concat prompt "\n" prompt-suffix)
+                         prompt)))
     (copilot-chat--prepare-buffers)
     (with-current-buffer copilot-chat--prompt-buffer
       (erase-buffer)
@@ -291,13 +291,15 @@ This function may be overriden by frontend."
 
 (defun copilot-chat--build-prompt-suffix ()
     "Build a prompt suffix with the current buffer name."
-    (let* ((major-mode-str (symbol-name major-mode))
-           (lang (replace-regexp-in-string "-mode$" "" major-mode-str))
-           (dynamic-suffix (format "current programming language is: %s" lang))
-           (suffix (if copilot-chat-prompt-suffix
-                       (concat dynamic-suffix ", " copilot-chat-prompt-suffix)
-                     dynamic-suffix)))
-        suffix))
+    (if (derived-mode-p 'prog-mode)  ; current buffer is a programming language buffer
+        (let* ((major-mode-str (symbol-name major-mode))
+               (lang (replace-regexp-in-string "-mode$" "" major-mode-str))
+               (dynamic-suffix (format "current programming language is: %s" lang))
+               (suffix (if copilot-chat-prompt-suffix
+                           (concat dynamic-suffix ", " copilot-chat-prompt-suffix)
+                         dynamic-suffix)))
+          suffix)
+      copilot-chat-prompt-suffix))
 
 (defun copilot-chat--custom-prompt-selection()
   "Send to Copilot a custom prompt followed by the current selected code.

--- a/test_copilot-chat.el
+++ b/test_copilot-chat.el
@@ -1,0 +1,30 @@
+
+(require 'ert)
+
+(defvar copilot-chat-prompt-suffix nil)
+
+(defun test-major-mode (mode)
+  "Helper function to set the major mode for testing."
+  (with-temp-buffer
+    (funcall mode)
+    (copilot-chat--build-prompt-suffix)))
+
+(ert-deftest test-copilot-chat--build-prompt-suffix-no-suffix ()
+  "Test copilot-chat--build-prompt-suffix with no custom suffix."
+  (let ((copilot-chat-prompt-suffix nil))
+    (should (equal (test-major-mode 'emacs-lisp-mode)
+                   "current programming language is: emacs-lisp"))))
+
+(ert-deftest test-copilot-chat--build-prompt-suffix-with-suffix ()
+  "Test copilot-chat--build-prompt-suffix with a custom suffix."
+  (let ((copilot-chat-prompt-suffix "additional info"))
+    (should (equal (test-major-mode 'emacs-lisp-mode)
+                   "current programming language is: emacs-lisp, additional info"))))
+
+(ert-deftest test-copilot-chat--build-prompt-suffix-different-mode ()
+  "Test copilot-chat--build-prompt-suffix with different major modes."
+  (let ((copilot-chat-prompt-suffix "extra details"))
+    (should (equal (test-major-mode 'python-mode)
+                   "current programming language is: python, extra details"))
+    (should (equal (test-major-mode 'c-mode)
+                   "current programming language is: c, extra details"))))


### PR DESCRIPTION
The PR added two features about the discussion context:

1. Provide current programming language as context. It is based on the major mode of editing buffer. During using copilot-chat.el, I found that, during editing emacs lisp, if I ask copilot chat to write a hello world function, it still write the code in python. But if the current programming language was provided, it will write the hello world in emacs lisp. So it might be helpful. It is provided through copilot-chat--build-prompt-suffix function.
2. Optional suffix (copilot-chat-prompt-suffix). If it is configured as non-nil, it will be provided as part of context for every prompt sent to copilot-chat. It is useful if we want the reply from copilot-chat written in language other than English.