### PR TITLE
Feat: Add syntax highlight to *Copilot-chat* buffer

### DIFF
--- a/copilot-chat-common.el
+++ b/copilot-chat-common.el
@@ -65,6 +65,12 @@
                  (const :tag "GPT-4o1-(preview)" "o1-preview"))
   :group 'copilot-chat)
 
+(defcustom copilot-chat-prompt-suffix nil
+  "Suffix to be added to the end of the prompt before sending to Copilot Chat. For Example: Reply in Chinese (or any other language)
+If nil, no suffix will be added."
+  :type 'string
+  :group 'copilot-chat)
+
 ;; structs
 (cl-defstruct copilot-chat
   ready

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -362,7 +362,7 @@ It can be used to review the magit diff for my change, or other people's"
   (interactive)
   (let* ((prompt "Question for copilot-chat: ")
          (input (read-string prompt nil 'copilot-chat--prompt-history)))
-    (copilot-chat--send-prompt input)
+    (copilot-chat--insert-and-send-prompt input)
     ))
 
 ;;;###autoload

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -280,9 +280,9 @@ Argument PROMPT is the prompt to send to Copilot."
   "Helper function to prepare buffers and send PROMPT to Copilot.
 This function may be overriden by frontend."
   (let* ((prompt-suffix (copilot-chat--build-prompt-suffix))
-           (final-prompt (if prompt-suffix
-                             (concat prompt "\n" prompt-suffix)
-                           prompt)))
+         (final-prompt (if prompt-suffix
+                           (concat prompt "\n" prompt-suffix)
+                         prompt)))
     (copilot-chat--prepare-buffers)
     (with-current-buffer copilot-chat--prompt-buffer
       (erase-buffer)
@@ -291,13 +291,15 @@ This function may be overriden by frontend."
 
 (defun copilot-chat--build-prompt-suffix ()
     "Build a prompt suffix with the current buffer name."
-    (let* ((major-mode-str (symbol-name major-mode))
-           (lang (replace-regexp-in-string "-mode$" "" major-mode-str))
-           (dynamic-suffix (format "current programming language is: %s" lang))
-           (suffix (if copilot-chat-prompt-suffix
-                       (concat dynamic-suffix ", " copilot-chat-prompt-suffix)
-                     dynamic-suffix)))
-        suffix))
+    (if (derived-mode-p 'prog-mode)  ; current buffer is a programming language buffer
+        (let* ((major-mode-str (symbol-name major-mode))
+               (lang (replace-regexp-in-string "-mode$" "" major-mode-str))
+               (dynamic-suffix (format "current programming language is: %s" lang))
+               (suffix (if copilot-chat-prompt-suffix
+                           (concat dynamic-suffix ", " copilot-chat-prompt-suffix)
+                         dynamic-suffix)))
+          suffix)
+      copilot-chat-prompt-suffix))
 
 (defun copilot-chat--custom-prompt-selection()
   "Send to Copilot a custom prompt followed by the current selected code.

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -386,12 +386,38 @@ It can be used to review the magit diff for my change, or other people's"
       (copilot-chat-list-mode))
     (switch-to-buffer buffer)))
 
+(defun copilot-chat--inherit-source-highlighting (source-buffer chat-buffer)
+  "Inherit syntax highlighting settings from SOURCE-BUFFER."
+  (with-current-buffer source-buffer
+    (let ((source-keywords font-lock-keywords)
+          (source-keywords-only font-lock-keywords-only)
+          (source-keywords-case-fold-search font-lock-keywords-case-fold-search)
+          (source-syntax-table (syntax-table))
+          (source-defaults font-lock-defaults))
+      (with-current-buffer chat-buffer
+        (set-syntax-table source-syntax-table)
+        (setq font-lock-defaults
+              (if source-defaults
+                  source-defaults
+                `((,source-keywords)
+                  nil
+                  ,source-keywords-case-fold-search)))
+        (setq font-lock-keywords source-keywords
+              font-lock-keywords-only source-keywords-only
+              font-lock-keywords-case-fold-search source-keywords-case-fold-search)
+        (font-lock-mode 1)
+        (font-lock-ensure)))))
+
 (defun copilot-chat--prepare-buffers()
   "Create copilot-chat buffers."
-  (let ((chat-buffer (get-buffer-create copilot-chat--buffer))
+  (let ((source-buffer (window-buffer (selected-window)))
+        (chat-buffer (get-buffer-create copilot-chat--buffer))
         (prompt-buffer (get-buffer-create copilot-chat--prompt-buffer)))
     (with-current-buffer chat-buffer
-      (copilot-chat-mode))
+      (copilot-chat-mode)
+      (when (with-current-buffer source-buffer
+              (derived-mode-p 'prog-mode))
+        (copilot-chat--inherit-source-highlighting source-buffer chat-buffer)))
     (with-current-buffer prompt-buffer
       (copilot-chat-prompt-mode))
   (list chat-buffer prompt-buffer)))

--- a/test_copilot-chat.el
+++ b/test_copilot-chat.el
@@ -1,0 +1,30 @@
+
+(require 'ert)
+
+(defvar copilot-chat-prompt-suffix nil)
+
+(defun test-major-mode (mode)
+  "Helper function to set the major mode for testing."
+  (with-temp-buffer
+    (funcall mode)
+    (copilot-chat--build-prompt-suffix)))
+
+(ert-deftest test-copilot-chat--build-prompt-suffix-no-suffix ()
+  "Test copilot-chat--build-prompt-suffix with no custom suffix."
+  (let ((copilot-chat-prompt-suffix nil))
+    (should (equal (test-major-mode 'emacs-lisp-mode)
+                   "current programming language is: emacs-lisp"))))
+
+(ert-deftest test-copilot-chat--build-prompt-suffix-with-suffix ()
+  "Test copilot-chat--build-prompt-suffix with a custom suffix."
+  (let ((copilot-chat-prompt-suffix "additional info"))
+    (should (equal (test-major-mode 'emacs-lisp-mode)
+                   "current programming language is: emacs-lisp, additional info"))))
+
+(ert-deftest test-copilot-chat--build-prompt-suffix-different-mode ()
+  "Test copilot-chat--build-prompt-suffix with different major modes."
+  (let ((copilot-chat-prompt-suffix "extra details"))
+    (should (equal (test-major-mode 'python-mode)
+                   "current programming language is: python, extra details"))
+    (should (equal (test-major-mode 'c-mode)
+                   "current programming language is: c, extra details"))))

--- a/test_copilot-chat.el
+++ b/test_copilot-chat.el
@@ -1,4 +1,6 @@
 
+;; tests for copilot-chat--build-prompt-suffix
+
 (require 'ert)
 
 (defvar copilot-chat-prompt-suffix nil)
@@ -28,3 +30,4 @@
                    "current programming language is: python, extra details"))
     (should (equal (test-major-mode 'c-mode)
                    "current programming language is: c, extra details"))))
+


### PR DESCRIPTION
The syntax highlight rule is from the major mode of code editoring buffer. 

I tried emacs-lisp, python, java. They works well.

Screenshot:

![Screenshot from 2024-12-06 18-27-11](https://github.com/user-attachments/assets/0127cb61-81ca-430b-906f-53e96ba54dfe)

