### PR TITLE
feat(chat): implement models API

### DIFF
--- a/copilot-chat-common.el
+++ b/copilot-chat-common.el
@@ -32,7 +32,8 @@
 
 ;; constants
 (defconst copilot-chat--magic "#cc#done#!$")
-(defconst copilot-chat--buffer-name "*Copilot-chat*")
+(defconst copilot-chat--buffer-name "*Copilot Chat*"
+  "Name of the Copilot Chat buffer.")
 
 ;; customs
 (defgroup copilot-chat nil
@@ -254,6 +255,10 @@ The create req function is called first and will return new prompt."
   (cl-find copilot-chat-frontend copilot-chat--frontend-list
            :key #'copilot-chat-frontend-id
            :test #'eq))
+
+(defun copilot-chat--get-buffer-name ()
+  "Get the formatted buffer name including model info."
+  (format "*Copilot Chat [%s]*" copilot-chat-model))
 
 (provide 'copilot-chat-common)
 ;;; copilot-chat-common.el ends here

--- a/copilot-chat-common.el
+++ b/copilot-chat-common.el
@@ -42,8 +42,8 @@
 (defcustom copilot-chat-frontend 'org
   "Frontend to use with `copilot-chat'.  Can be org or markdown."
   :type '(choice (const :tag "org-mode" org)
-                 (const :tag "markdown" markdown)
-                 (const :tag "shell-maker" shell-maker))
+          (const :tag "markdown" markdown)
+          (const :tag "shell-maker" shell-maker))
   :group 'copilot-chat)
 
 (defcustom copilot-chat-github-token-file "~/.config/copilot-chat/github-token"
@@ -62,10 +62,10 @@
 The list of available models will be updated when fetched from the API.
 Use `copilot-chat-set-model' to interactively select a model."
   :type '(choice (const :tag "GPT-4o" "gpt-4o")
-                 (const :tag "Claude 3.5 Sonnet" "claude-3.5-sonnet")
-                 (const :tag "Gemini 2.0 Flash" "gemini-2.0-flash-001")
-                 (const :tag "GPT-4o1-(preview)" "o1-preview")
-                 (const :tag "o3-mini" "o3-mini"))
+          (const :tag "Claude 3.5 Sonnet" "claude-3.5-sonnet")
+          (const :tag "Gemini 2.0 Flash" "gemini-2.0-flash-001")
+          (const :tag "GPT-4o1-(preview)" "o1-preview")
+          (const :tag "o3-mini" "o3-mini"))
   :group 'copilot-chat)
 
 (defcustom copilot-chat-prompt-suffix nil
@@ -164,7 +164,7 @@ If nil, no suffix will be added."
          :insert-prompt-fn #'copilot-chat--shell-maker-insert-prompt
          :pop-prompt-fn nil
          :goto-input-fn nil))
-    "Copilot-chat frontends and functions list.")
+  "Copilot-chat frontends and functions list.")
 
 (defvar copilot-chat--buffer nil)
 

--- a/copilot-chat-copilot.el
+++ b/copilot-chat-copilot.el
@@ -89,14 +89,14 @@
 
 (defun copilot-chat--create ()
   "Create a new Copilot chat instance."
-  (setq copilot-chat--instance(make-copilot-chat
-                              :ready t
-                              :github-token (copilot-chat--get-cached-token)
-                              :token nil
-                              :sessionid (concat (copilot-chat--uuid) (number-to-string (* (round (float-time (current-time))) 1000)))
-                              :machineid (copilot-chat--machine-id)
-                              :history nil
-                              :buffers nil)))
+  (setq copilot-chat--instance(copilot-chat--make
+                               :ready t
+                               :github-token (copilot-chat--get-cached-token)
+                               :token nil
+                               :sessionid (concat (copilot-chat--uuid) (number-to-string (* (round (float-time (current-time))) 1000)))
+                               :machineid (copilot-chat--machine-id)
+                               :history nil
+                               :buffers nil)))
 
 (defun copilot-chat--login()
   "Login to GitHub Copilot API."
@@ -110,15 +110,14 @@
 
 
 (defun copilot-chat--renew-token()
-    "Renew the session token."
-(cond
+  "Renew the session token."
+  (cond
    ((eq copilot-chat-backend 'curl)
     (copilot-chat--curl-renew-token))
    ((eq copilot-chat-backend 'request)
     (copilot-chat--request-renew-token))
    (t
     (error "Unknown backend: %s" copilot-chat-backend))))
-
 
 (defun copilot-chat--auth()
   "Authenticate with GitHub Copilot API.
@@ -144,7 +143,7 @@ Then we need a session token."
 Argument PROMPT is the prompt to send to copilot.
 Argument CALLBACK is the function to call with copilot answer as argument.
 Argument OUT-OF-CONTEXT is a boolean to indicate if the prompt is out of context."
- (let* ((history (copilot-chat-history copilot-chat--instance))
+  (let* ((history (copilot-chat-history copilot-chat--instance))
          (new-history (cons (list prompt "user") history)))
     (copilot-chat--auth)
     (cond
@@ -160,7 +159,7 @@ Argument OUT-OF-CONTEXT is a boolean to indicate if the prompt is out of context
 (defun copilot-chat--add-buffer (buffer)
   "Add a BUFFER to copilot buffers list.
 Argument buffer is the buffer to add."
-    (unless (memq buffer (copilot-chat-buffers copilot-chat--instance))
+  (unless (memq buffer (copilot-chat-buffers copilot-chat--instance))
     (let* ((buffers (copilot-chat-buffers copilot-chat--instance))
            (new-buffers (cons buffer buffers)))
       (setf (copilot-chat-buffers copilot-chat--instance) new-buffers))))

--- a/copilot-chat-curl.el
+++ b/copilot-chat-curl.el
@@ -83,6 +83,31 @@ authentication."
   :type 'boolean
   :group 'copilot-chat)
 
+(defcustom copilot-chat-spinner-frames
+  '("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
+  "Frames used for the spinner animation during streaming."
+  :type '(repeat string)
+  :group 'copilot-chat)
+
+(defcustom copilot-chat-spinner-interval 0.1
+  "Interval in seconds between spinner frame updates."
+  :type 'number
+  :group 'copilot-chat)
+
+(defface copilot-chat-spinner-face
+  '((t :inherit font-lock-keyword-face))
+  "Face used for the spinner during streaming."
+  :group 'copilot-chat)
+
+(defvar copilot-chat--spinner-timer nil
+  "Timer for the spinner animation.")
+
+(defvar copilot-chat--spinner-index 0
+  "Current index in the spinner frames.")
+
+(defvar copilot-chat--spinner-status nil
+  "Current status message to display with the spinner.")
+
 
 ;;variables
 (defvar copilot-chat--curl-answer nil)
@@ -101,10 +126,10 @@ Arguments ARGS are additional arguments to pass to curl."
                           "-s"
                           "-X" (if (eq method 'post) "POST" "GET")
                           "-A" "user-agent: CopilotChat.nvim/2.0.0"
-  	                      "-H" "content-type: application/json"
-	                      "-H" "accept: application/json"
-	                      "-H" "editor-plugin-version: CopilotChat.nvim/2.0.0"
-	                      "-H" "editor-version: Neovim/0.10.0")
+                          "-H" "content-type: application/json"
+                          "-H" "accept: application/json"
+                          "-H" "editor-plugin-version: CopilotChat.nvim/2.0.0"
+                          "-H" "editor-version: Neovim/0.10.0")
                     (when data (list "-d" data))
                     (when copilot-chat-curl-proxy (list "-x" copilot-chat-curl-proxy))
                     (when copilot-chat-curl-proxy-insecure (list "--proxy-insecure"))
@@ -131,23 +156,23 @@ Argument DATA is the data to send.
 Argument FILTER is the function called to parse data.
 Optional argument ARGS are additional arguments to pass to curl."
   (let ((command (append
-                    (list copilot-chat-curl-program
-                          address
-                          "-s"
-                          "-X" (if (eq method 'post) "POST" "GET")
-                          "-A" "user-agent: CopilotChat.nvim/2.0.0"
-  	                      "-H" "content-type: application/json"
-	                      "-H" "accept: application/json"
-	                      "-H" "editor-plugin-version: CopilotChat.nvim/2.0.0"
-	                      "-H" "editor-version: Neovim/0.10.0")
-                    (when data (list "-d" data))
-                    (when copilot-chat-curl-proxy (list "-x" copilot-chat-curl-proxy))
-                    (when copilot-chat-curl-proxy-insecure (list "--proxy-insecure"))
-                    (when copilot-chat-curl-proxy-user-pass
-                      (list
-                       "-U"
-                       copilot-chat-curl-proxy-user-pass))
-                    args)))
+                  (list copilot-chat-curl-program
+                        address
+                        "-s"
+                        "-X" (if (eq method 'post) "POST" "GET")
+                        "-A" "user-agent: CopilotChat.nvim/2.0.0"
+                        "-H" "content-type: application/json"
+                        "-H" "accept: application/json"
+                        "-H" "editor-plugin-version: CopilotChat.nvim/2.0.0"
+                        "-H" "editor-version: Neovim/0.10.0")
+                  (when data (list "-d" data))
+                  (when copilot-chat-curl-proxy (list "-x" copilot-chat-curl-proxy))
+                  (when copilot-chat-curl-proxy-insecure (list "--proxy-insecure"))
+                  (when copilot-chat-curl-proxy-user-pass
+                    (list
+                     "-U"
+                     copilot-chat-curl-proxy-user-pass))
+                  args)))
     (make-process
      :name "copilot-chat-curl"
      :buffer nil
@@ -163,38 +188,38 @@ Optional argument ARGS are additional arguments to pass to curl."
   "Curl github token request parsing."
   (goto-char (point-min))
   (let* ((json-data (json-parse-buffer
-					 :array-type 'list))
-		 (token (gethash "access_token" json-data))
-		 (token-dir (file-name-directory
-					 (expand-file-name copilot-chat-github-token-file))))
-	(setf (copilot-chat-github-token copilot-chat--instance) token)
+                     :array-type 'list))
+         (token (gethash "access_token" json-data))
+         (token-dir (file-name-directory
+                     (expand-file-name copilot-chat-github-token-file))))
+    (setf (copilot-chat-github-token copilot-chat--instance) token)
     (when (not (file-directory-p token-dir))
-	  (make-directory token-dir t))
+      (make-directory token-dir t))
     (with-temp-file copilot-chat-github-token-file
-	  (insert token))))
+      (insert token))))
 
 (defun copilot-chat--curl-parse-login()
   "Curl login request parsing."
   (goto-char (point-min))
   (let* ((json-data (json-parse-buffer
-					 :array-type 'list))
-  		 (device-code (gethash "device_code" json-data))
-		 (user-code (gethash "user_code" json-data))
-		 (verification-uri (gethash "verification_uri" json-data)))
-	(gui-set-selection 'CLIPBOARD user-code)
-	(read-from-minibuffer
-	 (format "Your one-time code %s is copied. \
+                     :array-type 'list))
+         (device-code (gethash "device_code" json-data))
+         (user-code (gethash "user_code" json-data))
+         (verification-uri (gethash "verification_uri" json-data)))
+    (gui-set-selection 'CLIPBOARD user-code)
+    (read-from-minibuffer
+     (format "Your one-time code %s is copied. \
 Press ENTER to open GitHub in your browser. \
 If your browser does not open automatically, browse to %s."
-			 user-code verification-uri))
-	(browse-url verification-uri)
-	(read-from-minibuffer "Press ENTER after authorizing.")
-	(with-temp-buffer
+             user-code verification-uri))
+    (browse-url verification-uri)
+    (read-from-minibuffer "Press ENTER after authorizing.")
+    (with-temp-buffer
       (copilot-chat--curl-call-process
-	   "https://github.com/login/oauth/access_token"
+       "https://github.com/login/oauth/access_token"
        'post
        (format "{\"client_id\":\"Iv1.b507a08c87ecfe98\",\"device_code\":\"%s\",\"grant_type\":\"urn:ietf:params:oauth:grant-type:device_code\"}" device-code))
-	  (copilot-chat--curl-parse-github-token))))
+      (copilot-chat--curl-parse-github-token))))
 
 
 (defun copilot-chat--curl-login()
@@ -204,7 +229,7 @@ If your browser does not open automatically, browse to %s."
      "https://github.com/login/device/code"
      'post
      "{\"client_id\":\"Iv1.b507a08c87ecfe98\",\"scope\":\"read:user\"}")
-	(copilot-chat--curl-parse-login)))
+    (copilot-chat--curl-parse-login)))
 
 
 (defun copilot-chat--curl-parse-renew-token()
@@ -212,28 +237,28 @@ If your browser does not open automatically, browse to %s."
   (switch-to-buffer (current-buffer))
   (goto-char (point-min))
   (let ((json-data (json-parse-buffer
-					:object-type 'alist ;need alist to be compatible with
+                    :object-type 'alist ;need alist to be compatible with
                                         ;copilot-chat-token format
-					:array-type 'list))
-		(cache-dir (file-name-directory (expand-file-name copilot-chat-token-cache))))
-	(setf (copilot-chat-token copilot-chat--instance) json-data)
-	;; save token in copilot-chat-token-cache file after creating
-	;; folders if needed
+                    :array-type 'list))
+        (cache-dir (file-name-directory (expand-file-name copilot-chat-token-cache))))
+    (setf (copilot-chat-token copilot-chat--instance) json-data)
+    ;; save token in copilot-chat-token-cache file after creating
+    ;; folders if needed
     (when (not (file-directory-p cache-dir))
-	  (make-directory  cache-dir t))
+      (make-directory  cache-dir t))
     (with-temp-file copilot-chat-token-cache
-	  (insert (json-encode json-data)))))
+      (insert (json-encode json-data)))))
 
 
 (defun copilot-chat--curl-renew-token()
   "Renew session token."
   (with-temp-buffer
     (copilot-chat--curl-call-process
-	 "https://api.github.com/copilot_internal/v2/token"
+     "https://api.github.com/copilot_internal/v2/token"
      'get
      nil
-	 "-H" (format "authorization: token %s" (copilot-chat-github-token copilot-chat--instance)))
-	(copilot-chat--curl-parse-renew-token)))
+     "-H" (format "authorization: token %s" (copilot-chat-github-token copilot-chat--instance)))
+    (copilot-chat--curl-parse-renew-token)))
 
 
 (defun copilot-chat--curl-extract-segment (segment)
@@ -274,7 +299,8 @@ Argument SEGMENT is data segment to parse."
   "Analyse curl resonse.
 Argument PROC is curl process.
 Argument STRING is the data returned by curl.
-Argument CALLBACK is the function to call with analysed data."
+Argument CALLBACK is the function to call with analysed data.
+Argument NO-HISTORY is a boolean to indicate if the response should be added to history."
   ;; The API conceptually sends us big blob of line-deliminated information, e.g.
   ;;
   ;;     data: {"choices":[{...,"delta":{"content":"great"}}],...}
@@ -323,9 +349,12 @@ Argument CALLBACK is the function to call with analysed data."
           (setq copilot-chat--curl-current-data segment))
          ;; Final segment, all done:
          ((eq extracted 'done)
+          (copilot-chat--spinner-stop)
           (funcall callback copilot-chat--magic)
           (unless no-history
-            (setf (copilot-chat-history copilot-chat--instance) (cons (list copilot-chat--curl-answer "assistant") (copilot-chat-history copilot-chat--instance))))
+            (setf (copilot-chat-history copilot-chat--instance)
+                  (cons (list copilot-chat--curl-answer "assistant")
+                        (copilot-chat-history copilot-chat--instance))))
           (setq copilot-chat--curl-answer nil))
 
          ;; Otherwise, JSON parsed successfully
@@ -337,11 +366,14 @@ Argument CALLBACK is the function to call with analysed data."
                    (delta (and (> (length choices) 0) (alist-get 'delta (aref choices 0))))
                    (token (and delta (alist-get 'content delta))))
               (when (and token (not (eq token :null)))
+                (when (not copilot-chat--curl-answer)
+                  (copilot-chat--spinner-set-status "Generating"))
                 (funcall callback token)
                 (setq copilot-chat--curl-answer (concat copilot-chat--curl-answer token)))))
 
            ;; display .error.message in the chat.
            ((alist-get 'error extracted)
+            (copilot-chat--spinner-stop)
             (let* ((err-response (alist-get 'error extracted))
                    (err-message (alist-get 'message err-response))
                    (answer (format "Error: %s" err-message)))
@@ -349,12 +381,69 @@ Argument CALLBACK is the function to call with analysed data."
               (funcall callback answer)
               (funcall callback copilot-chat--magic)
               ;; Add an empty response to the chat history to avoid confusing the assistant with its own error messages...
-              (setf (copilot-chat-history copilot-chat--instance) (cons (list "" "assistant") (copilot-chat-history copilot-chat--instance)))
+              (setf (copilot-chat-history copilot-chat--instance)
+                    (cons (list "" "assistant")
+                          (copilot-chat-history copilot-chat--instance)))
               (setq copilot-chat--curl-answer nil)))
            ;; Fallback -- nag developers about possibly unhandled payloads
            (t
             (warn "Unhandled message from copilot: %S" extracted)))))))))
 
+
+(defun copilot-chat--spinner-start ()
+  "Start the spinner animation in the Copilot Chat buffer."
+  (when copilot-chat--spinner-timer
+    (cancel-timer copilot-chat--spinner-timer))
+
+  (setq copilot-chat--spinner-index 0
+        copilot-chat--spinner-status "Thinking")
+
+  (setq copilot-chat--spinner-timer
+        (run-with-timer 0 copilot-chat-spinner-interval
+                        #'copilot-chat--spinner-update)))
+
+(defun copilot-chat--spinner-update ()
+  "Update the spinner animation in the Copilot Chat buffer."
+  (when (and copilot-chat--buffer (buffer-live-p copilot-chat--buffer))
+    (with-current-buffer copilot-chat--buffer
+      (let ((frame (nth copilot-chat--spinner-index copilot-chat-spinner-frames))
+            (status-text (if copilot-chat--spinner-status
+                             (concat copilot-chat--spinner-status " ")
+                           "")))
+        ;; Remove existing spinner overlay if any
+        (remove-overlays (point-min) (point-max) 'copilot-chat-spinner t)
+
+        ;; Create new spinner overlay at the end of buffer
+        (save-excursion
+          (goto-char (point-max))
+          (let ((ov (make-overlay (point) (point))))
+            (overlay-put ov 'copilot-chat-spinner t)
+            (overlay-put ov 'after-string
+                         (propertize (concat status-text frame)
+                                     'face 'copilot-chat-spinner-face)))))
+
+      ;; Update spinner index
+      (setq copilot-chat--spinner-index
+            (% (1+ copilot-chat--spinner-index)
+               (length copilot-chat-spinner-frames))))))
+
+(defun copilot-chat--spinner-stop ()
+  "Stop the spinner animation."
+  (when copilot-chat--spinner-timer
+    (cancel-timer copilot-chat--spinner-timer)
+    (setq copilot-chat--spinner-timer nil))
+
+  ;; Remove spinner overlay
+  (when (and copilot-chat--buffer (buffer-live-p copilot-chat--buffer))
+    (with-current-buffer copilot-chat--buffer
+      (remove-overlays (point-min) (point-max) 'copilot-chat-spinner t))))
+
+(defun copilot-chat--spinner-set-status (status)
+  "Set the status message to display with the spinner.
+Argument STATUS is the status message to display."
+  (setq copilot-chat--spinner-status status)
+  (when copilot-chat--spinner-timer
+    (copilot-chat--spinner-update)))
 
 (defun copilot-chat--curl-ask(prompt callback out-of-context)
   "Ask a question to Copilot using curl backend.
@@ -362,23 +451,29 @@ Argument PROMPT is the prompt to send to copilot.
 Argument CALLBACK is the function to call with copilot answer as argument.
 Argument OUT-OF-CONTEXT is a boolean to indicate if the prompt is out of context."
   (setq copilot-chat--curl-current-data nil)
+  (setq copilot-chat--curl-answer nil)
+
+  ;; Start the spinner animation
+  (copilot-chat--spinner-start)
+
   (when copilot-chat--curl-file
-	(delete-file copilot-chat--curl-file))
+    (delete-file copilot-chat--curl-file))
   (setq copilot-chat--curl-file (make-temp-file "copilot-chat"))
   (with-temp-file copilot-chat--curl-file
     (insert (copilot-chat--create-req prompt out-of-context)))
+
   (copilot-chat--curl-make-process
    "https://api.githubcopilot.com/chat/completions"
-    'post
-    (concat "@" copilot-chat--curl-file)
-    (lambda (proc string)
-      (copilot-chat--curl-analyze-response proc string callback out-of-context))
-    "-H" "openai-intent: conversation-panel"
-  	"-H" (concat "authorization: Bearer " (alist-get 'token (copilot-chat-token copilot-chat--instance)))
-  	"-H" (concat "x-request-id: " (copilot-chat--uuid))
-  	"-H" (concat "vscode-sessionid: " (copilot-chat-sessionid copilot-chat--instance))
-  	"-H" (concat "vscode-machineid: " (copilot-chat-machineid copilot-chat--instance))
-  	"-H" "copilot-integration-id: vscode-chat"))
+   'post
+   (concat "@" copilot-chat--curl-file)
+   (lambda (proc string)
+     (copilot-chat--curl-analyze-response proc string callback out-of-context))
+   "-H" "openai-intent: conversation-panel"
+   "-H" (concat "authorization: Bearer " (alist-get 'token (copilot-chat-token copilot-chat--instance)))
+   "-H" (concat "x-request-id: " (copilot-chat--uuid))
+   "-H" (concat "vscode-sessionid: " (copilot-chat-sessionid copilot-chat--instance))
+   "-H" (concat "vscode-machineid: " (copilot-chat-machineid copilot-chat--instance))
+   "-H" "copilot-integration-id: vscode-chat"))
 
 
 (provide 'copilot-chat-curl)

--- a/copilot-chat-markdown.el
+++ b/copilot-chat-markdown.el
@@ -40,7 +40,7 @@
 (define-derived-mode copilot-chat-markdown-prompt-mode markdown-mode "Copilot Chat markdown Prompt"
   "Major mode for the Copilot Chat Prompt region."
   (setq major-mode 'copilot-chat-markdown-prompt-mode
-    mode-name "Copilot Chat markdown prompt")
+        mode-name "Copilot Chat markdown prompt")
   (copilot-chat-prompt-mode))
 
 (define-hostmode poly-copilot-markdown-hostmode
@@ -65,13 +65,13 @@ Argument CONTENT is the data to format.
 Argument TYPE is the type of data to format: `answer` or `prompt`."
   (let ((data ""))
     (if (eq type 'prompt)
-	  (progn
-	    (setq copilot-chat--first-word-answer t)
-	    (setq data (concat "\n# " (format-time-string "*[%T]* You\n") (format "%s\n" content))))
-	  (when copilot-chat--first-word-answer
-	    (setq copilot-chat--first-word-answer nil)
+        (progn
+          (setq copilot-chat--first-word-answer t)
+          (setq data (concat "\n# " (format-time-string "*[%T]* You\n") (format "%s\n" content))))
+      (when copilot-chat--first-word-answer
+        (setq copilot-chat--first-word-answer nil)
         (setq data (concat "\n## " (format-time-string "*[%T]* Copilot\n"))))
-	  (setq data (concat data content)))
+      (setq data (concat data content)))
     data))
 
 (defun copilot-chat--markdown-format-code(code language)
@@ -79,7 +79,7 @@ Argument TYPE is the type of data to format: `answer` or `prompt`."
 Argument CODE is the code to format.
 Argument LANGUAGE is the language of the code."
   (if language
-    (format "\n```%s\n%s\n```\n" language code)
+      (format "\n```%s\n%s\n```\n" language code)
     code))
 
 (defun copilot-chat--markdown-clean()
@@ -95,7 +95,7 @@ Argument LANGUAGE is the language of the code."
       (let* ((begin-block (previous-single-property-change (point) 'face))
              (end-block (next-single-property-change (point) 'face))
              (content (when (and begin-block end-block)
-                       (buffer-substring-no-properties begin-block end-block)))
+                        (buffer-substring-no-properties begin-block end-block)))
              ;; Try to get language from previous text properties
              (lang-props (text-properties-at (max (- begin-block 1) (point-min))))
              (lang (plist-get lang-props 'markdown-language)))
@@ -107,13 +107,13 @@ Argument LANGUAGE is the language of the code."
   "Send the code block at point to buffer.
 Replace selection if any."
   (let ((buffer (completing-read "Choose buffer: "
-                  (mapcar #'buffer-name (buffer-list))
-                  nil  ; PREDICATE
-                  t    ; REQUIRE-MATCH
-                  nil  ; INITIAL-INPUT
-                  'buffer-name-history
-                  (buffer-name (current-buffer))))
-         (content (copilot-chat--get-markdown-block-content-at-point)))
+                                 (mapcar #'buffer-name (buffer-list))
+                                 nil  ; PREDICATE
+                                 t    ; REQUIRE-MATCH
+                                 nil  ; INITIAL-INPUT
+                                 'buffer-name-history
+                                 (buffer-name (current-buffer))))
+        (content (copilot-chat--get-markdown-block-content-at-point)))
     (when content
       (with-current-buffer buffer
         (when (use-region-p)
@@ -132,7 +132,7 @@ Replace selection if any."
 The input is created if not found."
   (goto-char (point-max))
   (if (re-search-backward copilot-chat--markdown-delimiter nil t)
-    (forward-line 1)
+      (forward-line 1)
     (insert "\n\n")
     (let ((start (point))
           (inhibit-read-only t))
@@ -145,14 +145,14 @@ The input is created if not found."
 (defun copilot-chat--markdown-get-buffer()
   "Create copilot-chat buffers."
   (unless (buffer-live-p copilot-chat--buffer)
-    (setq copilot-chat--buffer (get-buffer-create copilot-chat--buffer-name))
+    (setq copilot-chat--buffer (get-buffer-create (copilot-chat--get-buffer-name)))
     (with-current-buffer copilot-chat--buffer
       (copilot-chat-markdown-poly-mode)
       (copilot-chat--markdown-goto-input)))
   copilot-chat--buffer)
 
 (defun copilot-chat--markdown-insert-prompt (prompt)
-    "Insert PROMPT in the chat buffer."
+  "Insert PROMPT in the chat buffer."
   (with-current-buffer (copilot-chat--markdown-get-buffer)
     (copilot-chat--markdown-goto-input)
     (unless (eobp)

--- a/copilot-chat-org.el
+++ b/copilot-chat-org.el
@@ -43,7 +43,7 @@
 (define-derived-mode copilot-chat-org-prompt-mode org-mode "Copilot Chat org Prompt"
   "Major mode for the Copilot Chat Prompt region."
   (setq major-mode 'copilot-chat-org-prompt-mode
-    mode-name "Copilot Chat org prompt")
+        mode-name "Copilot Chat org prompt")
   (copilot-chat-prompt-mode))
 
 (define-hostmode poly-copilot-org-hostmode
@@ -68,13 +68,13 @@ Argument CONTENT is the data to format.
 Argument TYPE is the type of the data (prompt or answer)."
   (let ((data ""))
     (if (eq type 'prompt)
-	  (progn
-	    (setq copilot-chat--first-word-answer t)
-	    (setq data (concat "\n* " (format-time-string "*[%T]* You                 :you:\n") (format "%s\n" content))))
-	  (when copilot-chat--first-word-answer
-	    (setq copilot-chat--first-word-answer nil)
+        (progn
+          (setq copilot-chat--first-word-answer t)
+          (setq data (concat "\n* " (format-time-string "*[%T]* You                 :you:\n") (format "%s\n" content))))
+      (when copilot-chat--first-word-answer
+        (setq copilot-chat--first-word-answer nil)
         (setq data (concat "\n** " (format-time-string "*[%T]* Copilot                 :copilot:\n"))))
-	  (setq data (concat data content)))
+      (setq data (concat data content)))
     data))
 
 (defun copilot-chat--org-format-code(code language)
@@ -82,7 +82,7 @@ Argument TYPE is the type of the data (prompt or answer)."
 Argument CODE is the code to format.
 Argument LANGUAGE is the language of the code."
   (if language
-    (format "\n#+BEGIN_SRC %s\n%s\n#+END_SRC\n" language code)
+      (format "\n#+BEGIN_SRC %s\n%s\n#+END_SRC\n" language code)
     code))
 
 (defun copilot-chat--org-create-req (prompt &optional no-context)
@@ -128,17 +128,17 @@ NO-CONTEXT is an optional flag (unused in current implementation)."
   "Send the code block at point to buffer.
 Replace selection if any."
   (let* ((element (org-element-at-point))
-          (mode (copilot-chat--get-language-mode element))
-          (matching-buffer (when mode (copilot-chat--find-matching-buffer mode)))
-          (default-buffer (or matching-buffer (current-buffer)))
-          (buffer (completing-read "Choose buffer: "
-                    (mapcar #'buffer-name (buffer-list))
-                    nil  ; PREDICATE
-                    t    ; REQUIRE-MATCH
-                    nil  ; INITIAL-INPUT
-                    'buffer-name-history
-                    (buffer-name default-buffer)))
-          (content (copilot-chat--get-org-block-content-at-point)))
+         (mode (copilot-chat--get-language-mode element))
+         (matching-buffer (when mode (copilot-chat--find-matching-buffer mode)))
+         (default-buffer (or matching-buffer (current-buffer)))
+         (buffer (completing-read "Choose buffer: "
+                                  (mapcar #'buffer-name (buffer-list))
+                                  nil  ; PREDICATE
+                                  t    ; REQUIRE-MATCH
+                                  nil  ; INITIAL-INPUT
+                                  'buffer-name-history
+                                  (buffer-name default-buffer)))
+         (content (copilot-chat--get-org-block-content-at-point)))
     (when content
       (with-current-buffer buffer
         (when (use-region-p)
@@ -146,47 +146,47 @@ Replace selection if any."
         (insert content))
       (let ((window (get-buffer-window buffer)))
         (if window
-          (select-window window)
+            (select-window window)
           (switch-to-buffer buffer))))))
 
 (defun copilot-chat--org-get-code-blocks-under-heading (heading-regex)
   "Get source blocks under headings matching HEADING-REGEX."
   (let ((blocks))
     (org-map-entries
-      (lambda ()
-        (let* ((heading-end (save-excursion (org-end-of-subtree t)))
-                (element-start (point)))
-          (setq blocks
-            (append blocks
-              (org-element-map
-                (org-element-parse-buffer 'element)
-                'src-block
-                (lambda (src-block)
-                  (when (and (>= (org-element-property :begin src-block) element-start)
-                          (<= (org-element-property :begin src-block) heading-end))
-                    (list :language (org-element-property :language src-block)
-                      :content (org-element-property :value src-block)
-                      :begin (org-element-property :begin src-block)
-                      :end (org-element-property :end src-block)))))))))
-      heading-regex)
+     (lambda ()
+       (let* ((heading-end (save-excursion (org-end-of-subtree t)))
+              (element-start (point)))
+         (setq blocks
+               (append blocks
+                       (org-element-map
+                           (org-element-parse-buffer 'element)
+                           'src-block
+                         (lambda (src-block)
+                           (when (and (>= (org-element-property :begin src-block) element-start)
+                                      (<= (org-element-property :begin src-block) heading-end))
+                             (list :language (org-element-property :language src-block)
+                                   :content (org-element-property :value src-block)
+                                   :begin (org-element-property :begin src-block)
+                                   :end (org-element-property :end src-block)))))))))
+     heading-regex)
     (seq-uniq blocks #'equal)))
 
 (defun copilot-chat--org-yank()
   (let ((content ""))
-	(with-current-buffer copilot-chat--buffer
-	  (let ((blocks (copilot-chat--org-get-code-blocks-under-heading "copilot")))
+    (with-current-buffer copilot-chat--buffer
+      (let ((blocks (copilot-chat--org-get-code-blocks-under-heading "copilot")))
         (when blocks
-		  (while (< copilot-chat--yank-index 1)
-			(setq copilot-chat--yank-index (+ (length blocks)
-                                             copilot-chat--yank-index)))
+          (while (< copilot-chat--yank-index 1)
+            (setq copilot-chat--yank-index (+ (length blocks)
+                                              copilot-chat--yank-index)))
           (when (> copilot-chat--yank-index (length blocks))
-			(setq copilot-chat--yank-index (- copilot-chat--yank-index
-                                             (length blocks))))
-		  (setq content (plist-get (car (last blocks copilot-chat--yank-index)) :content)))))
-	;; Delete previous yank if exists
+            (setq copilot-chat--yank-index (- copilot-chat--yank-index
+                                              (length blocks))))
+          (setq content (plist-get (car (last blocks copilot-chat--yank-index)) :content)))))
+    ;; Delete previous yank if exists
     (when (and copilot-chat--last-yank-start
                copilot-chat--last-yank-end)
-	  (delete-region copilot-chat--last-yank-start copilot-chat--last-yank-end))
+      (delete-region copilot-chat--last-yank-start copilot-chat--last-yank-end))
     ;; Insert new content
     (setq copilot-chat--last-yank-start (point))
     (insert content)
@@ -206,26 +206,26 @@ The input is created if not found."
   (goto-char (point-max))
   (let ((span (pm-innermost-span (point))))
     (if (and span
-          (not (eq (car span) nil)))  ; nil span-type means host mode
-      (goto-char (+ 1 (car (pm-innermost-range (point)))))
+             (not (eq (car span) nil)))  ; nil span-type means host mode
+        (goto-char (+ 1 (car (pm-innermost-range (point)))))
       (insert "\n\n")
       (let ((start (point))
-             (inhibit-read-only t))
+            (inhibit-read-only t))
         (insert copilot-chat--org-delimiter "\n\n")
         (add-text-properties start (point)
-          '(read-only t front-sticky t rear-nonsticky (read-only)))))))
+                             '(read-only t front-sticky t rear-nonsticky (read-only)))))))
 
 (defun copilot-chat--org-get-buffer()
   "Create copilot-chat buffers."
   (unless (buffer-live-p copilot-chat--buffer)
-    (setq copilot-chat--buffer (get-buffer-create copilot-chat--buffer-name))
+    (setq copilot-chat--buffer (get-buffer-create (copilot-chat--get-buffer-name)))
     (with-current-buffer copilot-chat--buffer
       (copilot-chat-org-poly-mode)
       (copilot-chat--org-goto-input)))
   copilot-chat--buffer)
 
 (defun copilot-chat--org-insert-prompt (prompt)
-    "Insert PROMPT in the chat buffer."
+  "Insert PROMPT in the chat buffer."
   (with-current-buffer (copilot-chat--org-get-buffer)
     (copilot-chat--org-goto-input)
     (unless (eobp)

--- a/copilot-chat-request.el
+++ b/copilot-chat-request.el
@@ -173,5 +173,103 @@ Argument OUT-OF-CONTEXT is a boolean to indicate if the prompt is out of context
                      (setf (copilot-chat-history copilot-chat--instance) (cons (list prompt "assistant") (copilot-chat-history copilot-chat--instance))))
                    (funcall callback copilot-chat--magic)))))
 
+(defun copilot-chat--get-headers ()
+  "Get headers for Copilot API requests."
+  `(("openai-intent" . "conversation-panel")
+    ("content-type" . "application/json")
+    ("accept" . "application/json")
+    ("user-agent" . "CopilotChat.nvim/2.0.0")
+    ("editor-plugin-version" . "CopilotChat.nvim/2.0.0")
+    ("authorization" . ,(concat "Bearer " (alist-get 'token (copilot-chat-token copilot-chat--instance))))
+    ("x-request-id" . ,(copilot-chat--uuid))
+    ("vscode-sessionid" . ,(copilot-chat-sessionid copilot-chat--instance))
+    ("vscode-machineid" . ,(copilot-chat-machineid copilot-chat--instance))
+    ("copilot-integration-id" . "vscode-chat")
+    ("openai-organization" . "github-copilot")
+    ("editor-version" . "Neovim/0.10.0")))
+
+(cl-defun copilot-chat--request-models-cb (&key response
+                                          &key data
+                                          &allow-other-keys)
+  "Handle models response from Copilot API.
+Argument DATA is the parsed JSON response.
+Argument RESPONSE is request-response object."
+  (unless (= (request-response-status-code response) 200)
+    (error "Failed to fetch models: %s" (request-response-status-code response)))
+  
+  (let* ((models-vector (alist-get 'data data))
+         (models (append models-vector nil))  ; Convert vector to list
+         (chat-models nil))
+    ;; Filter for chat models and extract capabilities
+    (dolist (model models)
+      (when (and (alist-get 'capabilities model)
+                 (equal (alist-get 'type (alist-get 'capabilities model)) "chat"))
+        (push model chat-models)))
+    
+    ;; Store models in instance and return them
+    (let ((sorted-models (nreverse chat-models)))
+      (setf (copilot-chat-models copilot-chat--instance) sorted-models)
+      
+      ;; Enable policies for models if needed
+      (dolist (model sorted-models)
+        (when (and (alist-get 'policy model)
+                   (equal (alist-get 'state (alist-get 'policy model)) "unconfigured"))
+          (copilot-chat--request-enable-model-policy (alist-get 'id model))))
+      
+      ;; Return the models list for immediate use
+      sorted-models)))
+
+(defun copilot-chat--request-enable-model-policy (model-id)
+  "Enable policy for MODEL-ID."
+  (let ((url (format "https://api.githubcopilot.com/models/%s/policy" model-id))
+        (headers (copilot-chat--get-headers))
+        (data (json-encode '((state . "enabled")))))
+    (when copilot-chat-debug
+      (message "Enabling policy for model %s" model-id))
+    (request url
+      :type "POST"
+      :headers headers
+      :data data
+      :parser 'json-read)))
+
+(defun copilot-chat--request-models ()
+  "Fetch available models from Copilot API."
+  (let ((url "https://api.githubcopilot.com/models")
+        (headers (copilot-chat--get-headers)))
+    (when copilot-chat-debug
+      (message "Fetching models from %s" url))
+    (request url
+      :type "GET"
+      :headers headers
+      :parser 'json-read
+      :complete #'copilot-chat--request-models-cb)))
+
+(defun copilot-chat--request-chat (prompt callback &optional stream)
+  "Send PROMPT to Copilot Chat API.
+CALLBACK is called with the response.
+If STREAM is non-nil, use streaming response."
+  (let* ((url (if (string-match-p "^o1-" copilot-chat-model)
+                  "https://api.githubcopilot.com/chat/completions"
+                "https://api.githubcopilot.com/chat/completions"))
+         (headers (copilot-chat--get-headers))
+         (data (json-encode
+                `((messages . ,(vector (list :role "user"
+                                           :content prompt)))
+                  (model . ,copilot-chat-model)
+                  (stream . ,(if stream t json-false))
+                  (temperature . 0.1)
+                  (top_p . 1)
+                  (n . 1)))))
+    (copilot-chat--debug-request "POST" url headers data)
+    (request url
+      :type "POST"
+      :headers headers
+      :data data
+      :parser 'json-read
+      :complete (lambda (&rest args)
+                  (when copilot-chat-debug
+                    (message "Response: %s" args))
+                  (apply callback args)))))
+
 (provide 'copilot-chat-request)
 ;;; copilot-chat-request.el ends here

--- a/copilot-chat-shell-maker.el
+++ b/copilot-chat-shell-maker.el
@@ -41,8 +41,8 @@
 (defvar copilot-chat--shell-cb-fn nil)
 (defvar copilot-chat--shell-config
   (make-shell-maker-config
-    :name "Copilot-Chat"
-    :execute-command 'copilot-chat--shell-cb))
+   :name "Copilot-Chat"
+   :execute-command 'copilot-chat--shell-cb))
 (defvar copilot-chat--shell-maker-answer-point 0
   "Start of the current answer.")
 
@@ -62,7 +62,7 @@
   (unless (buffer-live-p copilot-chat--buffer)
     (setq copilot-chat--buffer (copilot-chat--shell)))
   (let ((tempb (get-buffer-create copilot-chat--shell-maker-temp-buffer))
-         (inhibit-read-only t))
+        (inhibit-read-only t))
     (with-current-buffer tempb
       (markdown-view-mode))
     copilot-chat--buffer))
@@ -75,7 +75,7 @@
       (goto-char (point-min))
       (while (not (eobp))
         (let ((next-change (or (next-property-change (point) nil (point-max)) (point-max)))
-               (face (get-text-property (point) 'face)))
+              (face (get-text-property (point) 'face)))
           (when face
             (font-lock-append-text-property (point) next-change 'font-lock-face face))
           (goto-char next-change))))))
@@ -103,15 +103,15 @@ Argument CONTENT is copilot chat answer."
     (when copilot-chat--first-word-answer
       (setq copilot-chat--first-word-answer nil)
       (let ((str (format-time-string "# [%T] Copilot:\n"))
-             (inhibit-read-only t))
+            (inhibit-read-only t))
         (with-current-buffer copilot-chat--shell-maker-temp-buffer
           (insert str))
         (funcall (map-elt shell :write-output) str)))
     (if (string= content copilot-chat--magic)
-      (progn
-        (funcall (map-elt shell :finish-output) t); the end
-        (copilot-chat--shell-maker-copy-faces)
-        (setq copilot-chat--first-word-answer t))
+        (progn
+          (funcall (map-elt shell :finish-output) t); the end
+          (copilot-chat--shell-maker-copy-faces)
+          (setq copilot-chat--first-word-answer t))
       (progn
         (with-current-buffer copilot-chat--shell-maker-temp-buffer
           (goto-char (point-max))
@@ -124,7 +124,7 @@ Argument CONTENT is copilot chat answer."
 Argument SHELL is the shell-maker instance.
 Argument CONTENT is copilot chat answer."
   (if copilot-chat-shell-maker-follow
-    (copilot-chat--shell-cb-prompt shell content)
+      (copilot-chat--shell-cb-prompt shell content)
     (save-excursion
       (copilot-chat--shell-cb-prompt shell content))))
 
@@ -134,9 +134,9 @@ Argument COMMAND is the command to send to Copilot.
 Argument CALLBACK is the callback function to call.
 Argument ERROR-CALLBACK is the error callback function to call."
   (setq
-    copilot-chat--shell-cb-fn
-    (apply-partially #'copilot-chat--shell-cb-prompt-wrapper shell)
-    copilot-chat--shell-maker-answer-point (point))
+   copilot-chat--shell-cb-fn
+   (apply-partially #'copilot-chat--shell-cb-prompt-wrapper shell)
+   copilot-chat--shell-maker-answer-point (point))
   (let ((inhibit-read-only t))
     (with-current-buffer copilot-chat--shell-maker-temp-buffer
       (erase-buffer)))
@@ -145,9 +145,9 @@ Argument ERROR-CALLBACK is the error callback function to call."
 (defun copilot-chat--shell ()
   "Start a Copilot Chat shell."
   (shell-maker-start
-    copilot-chat--shell-config
-    t nil t
-    copilot-chat--buffer-name))
+   copilot-chat--shell-config
+   t nil t
+   (copilot-chat--get-buffer-name)))
 
 (defun copilot-chat--shell-maker-insert-prompt(prompt)
   "Insert PROMPT in the chat buffer."

--- a/copilot-chat-transient.el
+++ b/copilot-chat-transient.el
@@ -65,7 +65,7 @@
     ("f" "Add files under current directory" copilot-chat-add-files-under-dir)
     ("l" "Display buffer list" copilot-chat-list)
     ("c" "Clear buffers" copilot-chat-list-clear-buffers)
-	("q" "Quit" transient-quit-one)]])
+    ("q" "Quit" transient-quit-one)]])
 
 ;;;###autoload (autoload 'copilot-chat-transient-code "copilot-chat" nil t)
 (transient-define-prefix copilot-chat-transient-code ()
@@ -81,6 +81,6 @@
     ("F" "Explain function" copilot-chat-explain-defun)
     ("c" "Custom prompt function" copilot-chat-custom-prompt-function)
     ("R" "Review whole buffer" copilot-chat-review-whole-buffer)
-	("q" "Quit" transient-quit-one)]])
+    ("q" "Quit" transient-quit-one)]])
 
 (provide 'copilot-chat-transient)

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -52,7 +52,7 @@
   :group 'copilot-chat)
 
 (defcustom copilot-chat-ignored-commit-files
-  '("pnpm-lock.yaml" "package-lock.json" "yarn.lock" "poetry.lock" 
+  '("pnpm-lock.yaml" "package-lock.json" "yarn.lock" "poetry.lock"
     "Cargo.lock" "go.sum" "composer.lock" "Gemfile.lock"
     "requirements.txt" "*.pyc" "*.pyo" "*.pyd"
     "*.so" "*.dylib" "*.dll" "*.exe"
@@ -82,9 +82,9 @@ Supports glob patterns like '*.lock' or 'node_modules/'."
     (define-key map (kbd "C-c RET") 'copilot-chat-prompt-send)
     (define-key map (kbd "C-c C-c") 'copilot-chat-prompt-send)
     (define-key map (kbd "C-c C-q") (lambda()
-                                    (interactive)
-                                    (bury-buffer)
-                                    (delete-window)))
+                                      (interactive)
+                                      (bury-buffer)
+                                      (delete-window)))
     (define-key map (kbd "C-c C-l") 'copilot-chat-prompt-split-and-list)
     (define-key map (kbd "C-c C-t") 'copilot-chat-transient)
     (define-key map (kbd "M-p") 'copilot-chat-prompt-history-previous)
@@ -126,7 +126,7 @@ Argument DATA data to be inserted in buffer."
       (with-current-buffer buffer
         (insert data))
     (with-current-buffer (copilot-chat--get-buffer)
-	  (let ((write-fn (copilot-chat-frontend-write-fn (copilot-chat--get-frontend))))
+      (let ((write-fn (copilot-chat-frontend-write-fn (copilot-chat--get-frontend))))
         (save-excursion
           (when write-fn
             (funcall write-fn data)))))))
@@ -141,7 +141,7 @@ Argument TYPE is the type of data to format: `answer` or `prompt`."
       content)))
 
 (defun copilot-chat-prompt-cb (content &optional buffer)
-    "Function called by backend when data is received.
+  "Function called by backend when data is received.
 Argument CONTENT is data received from backend.
 Optional argument BUFFER is the buffer to write data in."
   (if (string= content copilot-chat--magic)
@@ -179,9 +179,9 @@ Optional argument BUFFER is the buffer to write data in."
                                 (copilot-chat-prompt-cb content current-buf)))))
 
 (defun copilot-chat--ask-region(prompt)
-    "Send to Copilot a prompt followed by the current selected code.
+  "Send to Copilot a prompt followed by the current selected code.
 Argument PROMPT is the prompt to send to Copilot."
-    (let ((code (buffer-substring-no-properties (region-beginning) (region-end))))
+  (let ((code (buffer-substring-no-properties (region-beginning) (region-end))))
     (copilot-chat--insert-and-send-prompt
      (concat (cdr (assoc prompt (copilot-chat--prompts)))
              (copilot-chat--format-code code)))))
@@ -534,7 +534,7 @@ If there are more than 40 files, refuse to add and show warning message."
 
 
 (defun copilot-chat-send-to-buffer()
-    "Send the code block at point to buffer.
+  "Send the code block at point to buffer.
 Replace selection if any."
   (interactive)
   (let ((send-fn (copilot-chat-frontend-send-to-buffer-fn (copilot-chat--get-frontend))))
@@ -551,7 +551,7 @@ The diff is generated using `magit-git-insert' and excludes files
 matching patterns in `copilot-chat-ignored-commit-files', such as
 lock files and build artifacts."
   (let ((default-directory (or (magit-toplevel)
-                              (user-error "Not inside a Git repository"))))
+                               (user-error "Not inside a Git repository"))))
     (with-temp-buffer
       ;; First get list of staged files
       (magit-git-insert "diff" "--cached" "--name-only")
@@ -560,10 +560,10 @@ lock files and build artifacts."
               (cl-remove-if
                (lambda (file)
                  (cl-some (lambda (pattern)
-                           (or (string-match-p (wildcard-to-regexp pattern) file)
-                               (and (string-suffix-p "/" pattern)
-                                    (string-prefix-p pattern file))))
-                         copilot-chat-ignored-commit-files))
+                            (or (string-match-p (wildcard-to-regexp pattern) file)
+                                (and (string-suffix-p "/" pattern)
+                                     (string-prefix-p pattern file))))
+                          copilot-chat-ignored-commit-files))
                staged-files)))
         (erase-buffer)
         ;; Then get diff only for non-ignored files
@@ -589,10 +589,10 @@ No message is printed if `copilot-chat-debug' is nil."
     (unless (stringp format-string)
       (signal 'wrong-type-argument (list 'stringp format-string)))
     (let ((formatted-msg (condition-case err
-                            (apply #'format format-string args)
-                          (error
-                           (message "Error formatting debug message: %S" err)
-                           (format "Error formatting message with args: %S" args)))))
+                             (apply #'format format-string args)
+                           (error
+                            (message "Error formatting debug message: %S" err)
+                            (format "Error formatting message with args: %S" args)))))
       (message "[copilot-chat:%s] %s" category formatted-msg))))
 
 ;;;###autoload
@@ -608,12 +608,12 @@ Requires the repository to have staged changes."
   (let* ((diff (copilot-chat--get-diff))
          (prompt (concat copilot-chat-commit-prompt diff))
          (current-buf (current-buffer)))
-      
+
     ;; Debug messages using structured format
     (copilot-chat--debug 'commit "Starting commit message generation")
-    (copilot-chat--debug 'commit "Diff size: %d bytes, Model: %s" 
-                        (length diff) copilot-chat-model)
-      
+    (copilot-chat--debug 'commit "Diff size: %d bytes, Model: %s"
+                         (length diff) copilot-chat-model)
+
     (cond
      ((string-empty-p diff)
       (copilot-chat--debug 'commit "No changes found in staging area")
@@ -621,17 +621,17 @@ Requires the repository to have staged changes."
      (t
       (message "Generating commit message... Please wait for the model response.")
       (copilot-chat--ask prompt
-                        (lambda (content)
-                          (with-current-buffer current-buf
-                            (if (string= content copilot-chat--magic)
-                                (progn
-                                  (insert "\n")
-                                  (copilot-chat--debug 'commit "Generation completed"))
-                              (progn
-                                (insert content)
-                                (copilot-chat--debug 'commit "Received chunk: %d chars" 
-                                                    (length content))))))
-                        t)))))
+                         (lambda (content)
+                           (with-current-buffer current-buf
+                             (if (string= content copilot-chat--magic)
+                                 (progn
+                                   (insert "\n")
+                                   (copilot-chat--debug 'commit "Generation completed"))
+                               (progn
+                                 (insert content)
+                                 (copilot-chat--debug 'commit "Received chunk: %d chars"
+                                                      (length content))))))
+                         t)))))
 
 
 (defun copilot-chat--get-model-choices ()
@@ -639,35 +639,35 @@ Requires the repository to have staged changes."
 If models haven't been fetched yet, fetch them from the API."
   (unless (copilot-chat-models copilot-chat--instance)
     (copilot-chat--request-models))
-  
+
   (let ((models (copilot-chat-models copilot-chat--instance)))
     (if models
         ;; Return list of (name . id) pairs from fetched models, sorted by ID
         (sort
          (mapcar (lambda (model)
-                  (let* ((capabilities (alist-get 'capabilities model))
-                         (limits (alist-get 'limits capabilities))
-                         (max-output (or (alist-get 'max_output_tokens limits)
-                                       (if (string-prefix-p "o1" (alist-get 'id model))
-                                           100000  ; Set o1 models to 100k output tokens
-                                         nil))))
-                    (cons (format "%s (%s)%s%s\n  Tokens: %s/%s, Context: %s"
-                                (alist-get 'name model)
-                                (alist-get 'vendor model)
-                                (if (eq (alist-get 'preview model) t) " [Preview]" "")
-                                (if (and (alist-get 'policy model)
-                                        (equal (alist-get 'state (alist-get 'policy model)) "unconfigured"))
-                                    " [Policy Required]" "")
-                                (alist-get 'max_prompt_tokens limits)
-                                max-output
-                                (alist-get 'max_context_window_tokens limits))
-                          (alist-get 'id model))))
-                models)
+                   (let* ((capabilities (alist-get 'capabilities model))
+                          (limits (alist-get 'limits capabilities))
+                          (max-output (or (alist-get 'max_output_tokens limits)
+                                          (if (string-prefix-p "o1" (alist-get 'id model))
+                                              100000  ; Set o1 models to 100k output tokens
+                                            nil))))
+                     (cons (format "%s (%s)%s%s  Tokens: %s/%s, Context: %s"
+                                   (alist-get 'name model)
+                                   (alist-get 'vendor model)
+                                   (if (eq (alist-get 'preview model) t) " [Preview]" "")
+                                   (if (and (alist-get 'policy model)
+                                            (equal (alist-get 'state (alist-get 'policy model)) "unconfigured"))
+                                       " [Policy Required]" "")
+                                   (alist-get 'max_prompt_tokens limits)
+                                   max-output
+                                   (alist-get 'max_context_window_tokens limits))
+                           (alist-get 'id model))))
+                 models)
          (lambda (a b) (string< (cdr a) (cdr b))))
       ;; Fallback to default choices if models not fetched yet
       (let* ((type (get 'copilot-chat-model 'custom-type))
              (choices (when (eq (car type) 'choice)
-                       (cdr type))))
+                        (cdr type))))
         (sort
          (delq nil
                (mapcar (lambda (choice)
@@ -686,13 +686,13 @@ Fetches available models from the API if not already fetched."
    (let* ((choices (copilot-chat--get-model-choices))
           ;; Create completion list with ID as prefix for unique identification
           (completion-choices (mapcar (lambda (choice)
-                                      (let ((name (car choice))
-                                            (id (cdr choice)))
-                                        (cons (format "[%s] %s" id name) id)))
-                                    choices))
+                                        (let ((name (car choice))
+                                              (id (cdr choice)))
+                                          (cons (format "[%s] %s" id name) id)))
+                                      choices))
           (choice (completing-read "Select Copilot Chat model: "
-                                 (mapcar 'car completion-choices)
-                                 nil t)))
+                                   (mapcar 'car completion-choices)
+                                   nil t)))
      ;; Extract model ID from the selected choice
      (let ((model-value (cdr (assoc choice completion-choices))))
        (when copilot-chat-debug
@@ -707,8 +707,8 @@ Fetches available models from the API if not already fetched."
   "Insert last code block given by copilot-chat."
   (interactive)
   (setq copilot-chat--yank-index 1
-		copilot-chat--last-yank-start nil
-		copilot-chat--last-yank-end nil)
+	copilot-chat--last-yank-start nil
+	copilot-chat--last-yank-end nil)
   (copilot-chat--yank))
 
 (defun copilot-chat-yank-pop(&optional inc)
@@ -752,71 +752,6 @@ INC is the number to use as increment for index in block ring."
     (delete-file github-token-file))
   (message "Auth cache cleared.")
   (copilot-chat--create))
-
-;;;###autoload
-(defun copilot-chat-list-models ()
-  "List available Copilot Chat models and their capabilities."
-  (interactive)
-  (let ((models (copilot-chat-models copilot-chat--instance)))
-    (if (not models)
-        (progn
-          (message "Fetching models...")
-          (copilot-chat--request-models))
-      (with-current-buffer (get-buffer-create "*Copilot Models*")
-        (erase-buffer)
-        (insert "Available Copilot Chat Models:\n\n")
-        (dolist (model models)
-          (insert (format "* %s (%s)%s%s\n"
-                         (plist-get model :name)
-                         (plist-get model :vendor)
-                         (if (plist-get model :preview) " [Preview]" "")
-                         (if (equal (plist-get model :policy-state) "unconfigured") " [Policy Required]" ""))
-                  (format "  - ID: %s\n" (plist-get model :id))
-                  (format "  - Version: %s\n" (plist-get model :version))
-                  (format "  - Family: %s\n" (plist-get model :family))
-                  (format "  - Tokenizer: %s\n" (plist-get model :tokenizer))
-                  (format "  - Max prompt tokens: %s\n" (plist-get model :max-prompt-tokens))
-                  (format "  - Max output tokens: %s\n" (plist-get model :max-output-tokens))
-                  (format "  - Max context tokens: %s\n\n" (plist-get model :max-context-tokens))))
-        (goto-char (point-min))
-        (help-mode)
-        (display-buffer (current-buffer))))))
-
-(defun copilot-chat--debug-request (method url headers data)
-  "Log HTTP request details when `copilot-chat-debug' is enabled.
-
-Arguments:
-  METHOD: The HTTP method (e.g., \"GET\", \"POST\")
-  URL: The request URL
-  HEADERS: The request headers as an alist
-  DATA: The request body (optional)
-
-The function logs the request details in a structured format, including:
-- HTTP method
-- URL
-- Headers
-- Request body (if present)
-
-No logging occurs if `copilot-chat-debug' is nil."
-  (when copilot-chat-debug
-    (unless (stringp method)
-      (signal 'wrong-type-argument (list 'stringp method)))
-    (unless (stringp url)
-      (signal 'wrong-type-argument (list 'stringp url)))
-    (unless (listp headers)
-      (signal 'wrong-type-argument (list 'listp headers)))
-    
-    (message "\nCopilot Chat Request:")
-    (message "Method: %s" method)
-    (message "URL: %s" url)
-    (message "Headers: %s" (prin1-to-string headers))
-    (when data
-      (condition-case err
-          (message "Data: %s" (if (stringp data)
-                                 data
-                               (prin1-to-string data)))
-        (error
-         (message "Error formatting request data: %S" err))))))
 
 (provide 'copilot-chat)
 


### PR DESCRIPTION
Close #45

1. List models via the api `https://api.githubcopilot.com/models`;
2. Cache the models to ~/.cache/copilot-chat/models.json;
3. Improved set models:
![Xnip2025-02-26_00-02-59](https://github.com/user-attachments/assets/6f96ea0e-1f10-4c0a-9bfe-68e1d0667b9d)
4. Refine git commit get diff to ignore lock files;
5. Streaming messages;
