### PR TITLE
feat: add `o3-mini` to `copilot-chat-model`

### DIFF
--- a/copilot-chat-common.el
+++ b/copilot-chat-common.el
@@ -61,7 +61,8 @@
   "The model to use for Copilot chat."
   :type '(choice (const :tag "GPT-4o" "gpt-4o")
                  (const :tag "Claude 3.5 Sonnet" "claude-3.5-sonnet")
-                 (const :tag "GPT-4o1-(preview)" "o1-preview"))
+                 (const :tag "GPT-4o1-(preview)" "o1-preview")
+                 (const :tag "o3-mini" "o3-mini"))
   :group 'copilot-chat)
 
 (defcustom copilot-chat-prompt-suffix nil


### PR DESCRIPTION
Unlike o1, it worked just by adding it.
