### PR TITLE
feat: Add support for Claude 3.7 Sonnet model

### DIFF
--- a/copilot-chat-common.el
+++ b/copilot-chat-common.el
@@ -61,6 +61,7 @@
   "The model to use for Copilot chat."
   :type '(choice (const :tag "GPT-4o" "gpt-4o")
                  (const :tag "Claude 3.5 Sonnet" "claude-3.5-sonnet")
+                 (const :tag "Claude 3.7 Sonnet" "claude-3.7-sonnet")
                  (const :tag "Gemini 2.0 Flash" "gemini-2.0-flash-001")
                  (const :tag "GPT-4o1-(preview)" "o1-preview")
                  (const :tag "o3-mini" "o3-mini"))


### PR DESCRIPTION
Claude 3.7 Sonnet had been recently rolled out in the copilot: https://github.blog/changelog/2025-02-24-claude-3-7-sonnet-is-now-available-in-github-copilot-in-public-preview/

