### PR TITLE
feat: add `copilot-chat-model-ignore-picker` option

### DIFF
--- a/copilot-chat-common.el
+++ b/copilot-chat-common.el
@@ -86,6 +86,16 @@ Use `copilot-chat-set-model' to interactively select a model."
   :type 'string
   :group 'copilot-chat)
 
+(defcustom copilot-chat-model-ignore-picker nil
+  "Include models with the `model_picker_enabled' attribute set to `false'.
+For most people, a model with this attribute not `true` is useless,
+as it is a degraded version or has almost no difference.
+Therefore, to reduce noise,
+models whose `model_picker_enabled` attribute
+is not `true` are not included in the model selection by default."
+  :type 'boolean
+  :group 'copilot-chat)
+
 (defcustom copilot-chat-prompt-suffix nil
   "Suffix to be added to the end of the prompt before sending to Copilot Chat. For Example: Reply in Chinese (or any other language)
 If nil, no suffix will be added."

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -741,11 +741,17 @@ Requires the repository to have staged changes."
                                       (length content)))))))
        t)))))
 
+(defun copilot-chat--model-picker-enabled (model)
+  "Check the `model_picker_enabled` attribute of the MODEL.
+For example, GPT-3.5 has no more significance for most people nowadays than GPT-4o."
+  (eq t (alist-get 'model_picker_enabled model)))
 
 (defun copilot-chat--get-model-choices-with-wait ()
   "Get the list of available models for Copilot Chat, waiting for fetch if needed.
 If models haven't been fetched yet and no cache exists, wait for the fetch to complete."
-  (let ((models (copilot-chat-models copilot-chat--instance)))
+  (let ((models (if copilot-chat-model-ignore-picker
+                  (copilot-chat-models copilot-chat--instance)
+                  (seq-filter #'copilot-chat--model-picker-enabled (copilot-chat-models copilot-chat--instance)))))
     (if models
         ;; Return list of (name . id) pairs from fetched models, sorted by ID
         (sort


### PR DESCRIPTION
add `copilot-chat-model-ignore-picker` custom variable to filter model choices based on `model_picker_enabled` attribute.
Also add `copilot-chat--model-picker-enabled` function to apply filtering
with `copilot-chat--get-model-choices-with-wait` to prevent unnecessary models from being displayed.
