### PR TITLE
feat: display the Copilot model name in response

### DIFF
--- a/copilot-chat-markdown.el
+++ b/copilot-chat-markdown.el
@@ -70,7 +70,7 @@ Argument TYPE is the type of data to format: `answer` or `prompt`."
           (setq data (concat "\n# " (format-time-string "*[%T]* You\n") (format "%s\n" content))))
       (when copilot-chat--first-word-answer
         (setq copilot-chat--first-word-answer nil)
-        (setq data (concat "\n## " (format-time-string "*[%T]* Copilot\n"))))
+        (setq data (concat "\n## " (concat (format-time-string "*[%T]* ") (format "Copilot(%s):\n" copilot-chat-model)))))
       (setq data (concat data content)))
     data))
 

--- a/copilot-chat-org.el
+++ b/copilot-chat-org.el
@@ -73,7 +73,9 @@ Argument TYPE is the type of the data (prompt or answer)."
           (setq data (concat "\n* " (format-time-string "*[%T]* You                 :you:\n") (format "%s\n" content))))
       (when copilot-chat--first-word-answer
         (setq copilot-chat--first-word-answer nil)
-        (setq data (concat "\n** " (format-time-string "*[%T]* Copilot                 :copilot:\n"))))
+        (setq data (concat "\n** "
+                     (format-time-string "*[%T]* ")
+                     (format "Copilot(%s)                 :copilot:\n" copilot-chat-model))))
       (setq data (concat data content)))
     data))
 

--- a/copilot-chat-shell-maker.el
+++ b/copilot-chat-shell-maker.el
@@ -96,7 +96,7 @@ Argument CONTENT is copilot chat answer."
     (goto-char (point-max))
     (when copilot-chat--first-word-answer
       (setq copilot-chat--first-word-answer nil)
-      (let ((str (format-time-string "# [%T] Copilot:\n"))
+      (let ((str (concat (format-time-string "# [%T] ") (format "Copilot(%s):\n" copilot-chat-model)))
             (inhibit-read-only t))
         (with-current-buffer copilot-chat--shell-maker-temp-buffer
           (insert str))


### PR DESCRIPTION
The model name now appears in the buffer name,
but due to a refresh issue, it only shows the model when the buffer was created, causing me to be confused.
Also, when a model is changed after a response,
knowing which model the previous response was made with would reduce unnecessary queries.
Including the name of the model being used in the response header would solve these problems.
Either way, there is little overhead in displaying the information, since one line is used for the time display, etc.
