### PR TITLE
docs: fix formatting of quoted words in docstring

### DIFF
--- a/copilot-chat-common.el
+++ b/copilot-chat-common.el
@@ -88,11 +88,11 @@ Use `copilot-chat-set-model' to interactively select a model."
 
 (defcustom copilot-chat-model-ignore-picker nil
   "Include models with the `model_picker_enabled' attribute set to `false'.
-For most people, a model with this attribute not `true` is useless,
+For most people, a model with this attribute not `true' is useless,
 as it is a degraded version or has almost no difference.
 Therefore, to reduce noise,
-models whose `model_picker_enabled` attribute
-is not `true` are not included in the model selection by default."
+models whose `model_picker_enabled' attribute
+is not `true' are not included in the model selection by default."
   :type 'boolean
   :group 'copilot-chat)
 


### PR DESCRIPTION
Since I am not fluent in English,
I wrote this document comment in Japanese and then translated it at DeepL.
This is why I did not notice the incorrect syntax in the code highlighting.
It is a minor detail, but due to my own mismanagement, I have corrected it.
