### PR TITLE
fix: `copilot-chat--get-diff` work with multiple files

### DIFF
--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -593,9 +593,7 @@ lock files and build artifacts."
         (erase-buffer)
         ;; Then get diff only for non-ignored files
         (when files-to-include
-          (apply #'magit-git-insert
-                 (append '("diff" "--cached")
-                         files-to-include)))
+          (magit-git-insert (append '("diff" "--cached" "--") files-to-include))
         (buffer-string)))))
 
 (defun copilot-chat-goto-input()


### PR DESCRIPTION
git diff needs to separate argument positions with `--` when specifying multiple files.
Before the fix, it worked when a single file was staged, but not when multiple files were specified.
