### PR TITLE
`copilot-chat-custom-prompt-selection` add optional argument "prompt"

### DIFF
--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -269,15 +269,6 @@ Argument PROMPT is the prompt to send to Copilot."
       (funcall format-fn code (copilot-chat--get-language))
       code)))
 
-(defun copilot-chat--custom-prompt-selection()
-  "Send to Copilot a custom prompt followed by the current selected code."
-  (unless (copilot-chat--ready-p)
-    (copilot-chat-reset))
-  (let* ((prompt (read-from-minibuffer "Copilot prompt: "))
-          (code (buffer-substring-no-properties (region-beginning) (region-end)))
-          (formatted-prompt (concat prompt "\n" (copilot-chat--format-code code))))
-    (copilot-chat--insert-and-send-prompt formatted-prompt)))
-
 ;;;###autoload
 (defun copilot-chat-explain-symbol-at-line ()
   "Ask Copilot to explain symbol under point.
@@ -331,12 +322,19 @@ Side by side with the current code editing buffer."
   (switch-to-buffer-other-window (copilot-chat--get-buffer)))
 
 ;;;###autoload
-(defun copilot-chat-custom-prompt-selection()
-  "Send to Copilot a custom prompt followed by the current selected code."
+(defun copilot-chat-custom-prompt-selection(&optional custom-prompt)
+  "Send to Copilot a custom prompt followed by the current selected code/buffer.
+If CUSTOM-PROMPT is provided, use it instead of reading from the mini-buffer."
+
   (interactive)
   (unless (copilot-chat--ready-p)
     (copilot-chat-reset))
-  (copilot-chat--custom-prompt-selection))
+  (let* ((prompt (or custom-prompt (read-from-minibuffer "Copilot prompt: ")))
+          (code (if (use-region-p)
+                  (buffer-substring-no-properties (region-beginning) (region-end))
+                  (buffer-substring-no-properties (point-min) (point-max))))
+          (formatted-prompt (concat prompt "\n" (copilot-chat--format-code code))))
+    (copilot-chat--insert-and-send-prompt formatted-prompt)))
 
 ;;;###autoload
 (defun copilot-chat-custom-prompt-mini-buffer ()

--- a/readme.org
+++ b/readme.org
@@ -118,7 +118,7 @@ You can call ~(copilot-chat-transient)~ to open transient menu. Almost all funct
 *** Prompt
 - ~copilot-chat-goto-input~ place point at the beginning of the prompt area.
 - ~(copilot-chat-custom-mini-buffer)~ ask for a prompt in minibuffer and send it to copilot.
-- ~(copilot-chat-custom-prompt-selection)~ ask for a prompt in minibuffer and pastes selection after it before sending it to copilot.
+- ~(copilot-chat-custom-prompt-selection)~ uses the provided prompt or asks for a prompt in minibuffer, then appends selection (or entire buffer), sends the result to copilot.
 - ~(copilot-chat-prompt-history-previous)~ insert previous prompt from history in prompt buffer.
 - ~(copilot-chat-prompt-history-next)~ insert next prompt from history in prompt buffer.
 - ~(copilot-chat-ask-and-insert)~ ask for a custom prompt and write answer in current buffer at point.


### PR DESCRIPTION
Allow users to provide a custom prompt directly to the function copilot-chat-custom-prompt-selection. If no custom prompt is provided, the function will read from the mini-buffer.

This makes it easy to for users to create customized functions for example:
```elisp
(defun copilot-chat-correct-typos ()
  (interactive)
  (copilot-chat-custom-prompt-selection
   "Please fix typos in the following text "))
```
Another enhancement is: if the region is inactive, use the whole buffer.