### PR TITLE
ci: add dependabot for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 20

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,15 @@
+name: check
+
+on: push
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: purcell/setup-emacs@master
+        with:
+          version: 30.1
+      - uses: leotaku/elisp-check@master
+        with:
+          file: "*.el"


### PR DESCRIPTION
from [Can code format over the whole thing? · Issue #106 · chep/copilot-chat.el](https://github.com/chep/copilot-chat.el/issues/106)

I was able to set up the CI itself successfully, but the existing code ignores the error, so the checking mechanism is causing quite a few errors.
I'll try to fix a few things, like simple forgetting to specify a version, but in some cases I may need to do my best to fix them or specify that they are ignored to some degree.