### PR TITLE
fix: move remove operation of old spiner overlay to chat buffer

### DIFF
--- a/copilot-chat-curl.el
+++ b/copilot-chat-curl.el
@@ -449,12 +449,11 @@ if the response should be added to history."
             (status-text (if copilot-chat--spinner-status
                              (concat copilot-chat--spinner-status " ")
                            "")))
-        ;; Remove existing spinner overlay if any
-        (remove-overlays (point-min) (point-max) 'copilot-chat-spinner t)
-
-        ;; Create new spinner overlay at the end of buffer
         (with-current-buffer buffer
           (save-excursion
+            ;; Remove existing spinner overlay if any
+            (remove-overlays (point-min) (point-max) 'copilot-chat-spinner t)
+            ;; Create new spinner overlay at the end of buffer
             (goto-char (point-max))
             (let ((ov (make-overlay (point) (point))))
               (overlay-put ov 'copilot-chat-spinner t)


### PR DESCRIPTION
The previous operation would have been done in the current buffer,
so if I focused on a different buffer and waited for Copilot Chat to respond,
the `Thinking` string would cover up a lot of the buffer.
Even though it disappears after the last focus,
it is hard to read and uncomfortable to work with the output on the side.
