### PR TITLE
ci: pin elisp-check action version to v1.4.1

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: purcell/setup-emacs@v7.0
         with:
           version: 30.1
-      - uses: leotaku/elisp-check@master
+      - uses: leotaku/elisp-check@v1.4.1


### PR DESCRIPTION
Because resolved [Please release for version · Issue #31 · leotaku/elisp-check](https://github.com/leotaku/elisp-check/issues/31).
