### PR TITLE
fix(shell-maker): copilot chat use directory to one

### DIFF
--- a/copilot-chat-shell-maker.el
+++ b/copilot-chat-shell-maker.el
@@ -150,7 +150,7 @@ Argument SHELL is the `shell-maker' instance."
   "Start a Copilot Chat shell for INSTANCE."
   (let ((buf (shell-maker-start
                (make-shell-maker-config
-                 :name (format "Copilot-Chat %s" (copilot-chat-directory instance))
+                 :name (format "Copilot-Chat%s" (copilot-chat-directory instance))
                  :execute-command (lambda (command shell)
                                     (copilot-chat--shell-cb instance command shell)))
                t nil t


### PR DESCRIPTION
Maybe `shell-maker-start` make directory by name.
So I'm `~/.emacs.d` have two directory `copilot-chat` and `copilot-chat `.

```
 ❯ ll
合計 35M
drwxr-xr-x  20 ncaq ncaq 4.0K  3月 30 15:28  ./
drwxr-xr-x  54 ncaq ncaq 4.0K  3月 30 15:34  ../
drwxr-xr-x   5 ncaq ncaq 4.0K  2月 21 15:25  .cache/
drwxr-xr-x  11 ncaq ncaq 4.0K  3月 30 15:28  .git/
drwxr-xr-x   2 ncaq ncaq 4.0K  3月 30 15:34  auto-save-file/
drwx------   2 ncaq ncaq 4.0K  3月 30 15:31  auto-save-list/
drwxr-xr-x   3 ncaq ncaq 4.0K  3月 30 15:32  copilot-chat/
drwxr-xr-x   3 ncaq ncaq 4.0K  3月 30 15:28 'copilot-chat '/
drwxr-xr-x   3 ncaq ncaq 4.0K 12月  6 17:32  eclipse.jdt.ls/
drwxr-xr-x   3 ncaq ncaq 4.0K  3月 21 15:19  eln-cache/
drwxr-xr-x 182 ncaq ncaq  12K  3月 28 17:58  elpa/
drwxr-xr-x   3 ncaq ncaq 4.0K  7月 31  2023  elpy/
drwxr-xr-x   2 ncaq ncaq  88K  3月 30 15:27  file-backup/
drwxr-xr-x   2 ncaq ncaq 4.0K  3月 30 15:33  request/
drwxr-xr-x   8 ncaq ncaq 4.0K  8月 16  2023  snippets/
drwxr-xr-x   4 ncaq ncaq 4.0K  3月 21 15:19  straight/
drwxr-xr-x   2 ncaq ncaq 4.0K 11月  8 16:53  transient/
drwxr-xr-x   2 ncaq ncaq 4.0K  3月 10 19:24  tree-sitter/
drwxr-xr-x   2 ncaq ncaq 960K  3月 30 15:32  undo-tree/
drwxr-xr-x   2 ncaq ncaq 4.0K  1月 26  2023  url/
-rw-r--r--   1 ncaq ncaq   81  3月 30 15:28  .dap-breakpoints
-rw-r--r--   1 ncaq ncaq 2.3K  3月 30 15:31  .emacs.desktop
-rw-r--r--   1 ncaq ncaq    5  3月 30 15:28  .emacs.desktop.lock
-rw-r--r--   1 ncaq ncaq   87 11月 22  2023  .gitignore
-rw-r--r--   1 ncaq ncaq 5.9K  3月 28 16:25  .lsp-session-v1
-rw-r--r--   1 ncaq ncaq 2.4K  3月 24 17:02  .mc-lists.el
-rw-r--r--   1 ncaq ncaq  33K 10月  4  2022  LICENSE
-rw-r--r--   1 ncaq ncaq  321 10月  4  2022  README.md
-rw-r--r--   1 ncaq ncaq  733  3月 27 15:18  custom.el
-rw-r--r--   1 ncaq ncaq  733  6月 19  2024  early-init.el
-rw-r--r--   1 ncaq ncaq  17M  3月 30 15:28  forge-database.sqlite
-rw-r--r--   1 ncaq ncaq  17M  3月 27 17:30  forge-database-v14-20250327-1730.sqlite
-rw-------   1 ncaq ncaq  96K  3月 30 15:33  history
-rw-r--r--   1 ncaq ncaq  643  3月 13 19:41  ielm-history.eld
-rw-r--r--   1 ncaq ncaq  70K  3月 30 15:28  init.el
-rw-r--r--   1 ncaq ncaq  37K  3月 30 15:28  places
-rw-r--r--   1 ncaq ncaq  365  3月 14 16:07  projects
-rw-------   1 ncaq ncaq 1.4K  3月 30 15:28  recentf
-rw-r--r--   1 ncaq ncaq  315  3月 30 15:28  tramp
```

I honestly don't know how this directory helps shell-maker, because it's empty.
I guess I just don't use it in my current setup.
I think one directory used by one package for a similar purpose is enough.
And a directory that contains blank space is not pleasant.
So I will unify the existing `copilot-chat` directory.
