### PR TITLE
fix(chat): ensure chat buffer is recentered after writing

### DIFF
--- a/copilot-chat-command.el
+++ b/copilot-chat-command.el
@@ -80,6 +80,8 @@ to Copilot for processing."
         (copilot-chat--write-buffer
          instance
          (copilot-chat--format-data instance prompt 'prompt) nil)
+        (with-current-buffer (copilot-chat--get-buffer instance)
+          (recenter-top-bottom))
         (push prompt (copilot-chat-prompt-history instance))
         (setf (copilot-chat-prompt-history-position instance) nil)
         (copilot-chat--ask instance prompt 'copilot-chat-prompt-cb)))))


### PR DESCRIPTION
This change ensures that the chat buffer is recentered to improve visibility and usability when interacting with the Copilot chat instance.