### PR TITLE
alias `copilot-chat` command to `copilot-chat-display`

### DIFF
--- a/copilot-chat-body.el
+++ b/copilot-chat-body.el
@@ -36,7 +36,7 @@
   "Create a request for Copilot.
 Argument INSTANCE is the copilot chat instance to use.
 Argument PROMPT Copilot prompt to send.
-Argument NO-CONTEXT tells copilot-chat to not send history and buffers.
+Argument NO-CONTEXT tells `copilot-chat' to not send history and buffers.
 The create req function is called first and will return new prompt."
   (let* ((create-req-fn (copilot-chat-frontend-create-req-fn
                          (copilot-chat--get-frontend)))

--- a/copilot-chat-command.el
+++ b/copilot-chat-command.el
@@ -40,11 +40,11 @@
 ;; Faces
 (defface copilot-chat-list-selected-buffer-face
   '((t :inherit font-lock-keyword-face))
-  "Face used for selected buffers in copilot-chat buffer list."
+  "Face used for selected buffers in `copilot-chat' buffer list."
   :group 'copilot-chat)
 (defface copilot-chat-list-default-face
   '((t :inherit default))
-  "Face used for unselected buffers in copilot-chat buffer list."
+  "Face used for unselected buffers in `copilot-chat' buffer list."
   :group 'copilot-chat)
 
 ;; Variables
@@ -210,7 +210,7 @@ Given the code line as background info."
 
 ;;;###autoload (autoload 'copilot-chat-custom-prompt-function "copilot-chat" nil t)
 (defun copilot-chat-custom-prompt-function ()
-  "Mark current function and ask copilot-chat with custom prompt."
+  "Mark current function and ask `copilot-chat' with custom prompt."
   (interactive)
   (save-excursion
     (mark-defun)
@@ -358,7 +358,7 @@ Optional argument ARG if non-nil, force instance selection."
     (copilot-chat-list-refresh instance)))
 
 (defun copilot-chat-add-file (file-path)
-  "Add FILE-PATH to copilot-chat buffers without changing current window layout."
+  "Add FILE-PATH to `copilot-chat' buffers without changing current window layout."
   (interactive "fFile to add: ")
   (save-window-excursion
     (let ((current-buf (current-buffer)))
@@ -712,7 +712,7 @@ Fetches available models from the API if not already fetched."
     (message "Copilot Chat model set to %s" model)))
 
 (defun copilot-chat-yank()
-  "Insert last code block given by copilot-chat."
+  "Insert last code block given by `copilot-chat'."
   (interactive)
   (let ((instance (copilot-chat--current-instance)))
     (setf

--- a/copilot-chat-command.el
+++ b/copilot-chat-command.el
@@ -303,6 +303,9 @@ Optional argument ARG if non-nil, force instance selection."
                     (copilot-chat--current-instance))))
     (copilot-chat--display instance)))
 
+;;;###autoload (autoload 'copilot-chat "copilot-chat" nil t)
+(defalias 'copilot-chat 'copilot-chat-display)
+
 ;;;###autoload (autoload 'copilot-chat-hide "copilot-chat" nil t)
 (defun copilot-chat-hide ()
   "Hide copilot chat buffer."

--- a/copilot-chat-curl.el
+++ b/copilot-chat-curl.el
@@ -69,7 +69,7 @@ by using %40 or pass in a colon with %3a."
   :group 'copilot-chat)
 
 (defcustom copilot-chat-curl-proxy-insecure nil
-  "Insecure flag for copilot-chat proxy with curl backend.
+  "Insecure flag for `copilot-chat' proxy with curl backend.
 Every secure connection curl makes is verified to be secure before the
 transfer takes place.  This option makes curl skip the verification step
 with a proxy and proceed without checking."
@@ -77,7 +77,7 @@ with a proxy and proceed without checking."
   :group 'copilot-chat)
 
 (defcustom copilot-chat-curl-proxy-user-pass nil
-  "User password for copilot-chat proxy with curl backend.
+  "User password for `copilot-chat' proxy with curl backend.
 Specify the username and password <user:password> to use for proxy
 authentication."
   :type 'boolean

--- a/copilot-chat-markdown.el
+++ b/copilot-chat-markdown.el
@@ -70,7 +70,7 @@
 ;;; Functions
 (defun copilot-chat--markdown-format-data (instance content type)
   "Format the CONTENT according to the frontend.
-INSTANCE is copilot-chat instance to use.
+INSTANCE is `copilot-chat' instance to use.
 Argument TYPE is the type of data to format: `answer` or `prompt`."
   (let ((data ""))
     (if (eq type 'prompt)
@@ -169,7 +169,7 @@ The input is created if not found."
         (overlay-put overlay 'evaporate t)))))
 
 (defun copilot-chat--markdown-get-buffer (instance)
-  "Create copilot-chat buffers for INSTANCE."
+  "Create `copilot-chat' buffers for INSTANCE."
   (unless (buffer-live-p (copilot-chat-chat-buffer instance))
     (setf (copilot-chat-chat-buffer instance)
           (get-buffer-create (copilot-chat--get-buffer-name
@@ -199,7 +199,7 @@ The input is created if not found."
 
 (defun copilot-chat--markdown-pop-prompt (instance)
   "Get current prompt to send and clean it.
-INSTANCE is copilot-chat instance to use."
+INSTANCE is `copilot-chat' instance to use."
   (with-current-buffer (copilot-chat--markdown-get-buffer instance)
     (copilot-chat--markdown-goto-input)
     (let ((prompt (buffer-substring-no-properties (point) (point-max))))

--- a/copilot-chat-org.el
+++ b/copilot-chat-org.el
@@ -70,7 +70,7 @@
 ;;; Functions
 (defun copilot-chat--org-format-data(instance content type)
   "Format data for org frontend.
-INSTANCE is copilot-chat instance to use.
+INSTANCE is `copilot-chat' instance to use.
 Argument CONTENT is the data to format.
 Argument TYPE is the type of the data (prompt or answer)."
   (let ((data ""))
@@ -198,7 +198,7 @@ Replace selection if any."
 
 (defun copilot-chat--org-yank(instance)
   "Insert code block from Copilot Chat's org buffer at point.
-INSTANCE is copilot-chat instance to use."
+INSTANCE is `copilot-chat' instance to use."
   (let ((content ""))
     (with-current-buffer (copilot-chat-chat-buffer instance)
       (let ((blocks (copilot-chat--org-get-code-blocks-under-heading "copilot")))
@@ -246,7 +246,7 @@ The input is created if not found."
                              '(read-only t front-sticky t rear-nonsticky (read-only)))))))
 
 (defun copilot-chat--org-get-buffer(instance)
-  "Create copilot-chat buffers for INSTANCE."
+  "Create `copilot-chat' buffers for INSTANCE."
   (unless (buffer-live-p (copilot-chat-chat-buffer instance))
     (setf (copilot-chat-chat-buffer instance)
           (get-buffer-create (copilot-chat--get-buffer-name
@@ -267,7 +267,7 @@ The input is created if not found."
 
 (defun copilot-chat--org-pop-prompt(instance)
   "Get current prompt to send and clean it.
-INSTANCE is copilot-chat instance to use."
+INSTANCE is `copilot-chat' instance to use."
   (with-current-buffer (copilot-chat--org-get-buffer instance)
     (copilot-chat--org-goto-input)
     (let ((prompt (buffer-substring-no-properties (point) (point-max))))

--- a/copilot-chat-prompt-mode.el
+++ b/copilot-chat-prompt-mode.el
@@ -46,7 +46,7 @@
 (defvar copilot-chat--prompt-history nil
   "Copilot-chat prompt history.")
 (defvar copilot-chat--prompt-history-position nil
-  "Current position in copilot-chat prompt history.")
+  "Current position in `copilot-chat' prompt history.")
 
 (define-minor-mode copilot-chat-prompt-mode
   "Minor mode for the Copilot Chat Prompt region."

--- a/copilot-chat-shell-maker.el
+++ b/copilot-chat-shell-maker.el
@@ -99,7 +99,7 @@ INSTANCE is used to get directory"
 
 (defun copilot-chat--shell-cb-prompt (instance shell content)
   "Callback for Copilot Chat `shell-maker'.
-Argument INSTANCE is copilot-chat instance.
+Argument INSTANCE is `copilot-chat' instance.
 Argument SHELL is the `shell-maker' instance.
 Argument CONTENT is copilot chat answer."
   (with-current-buffer (copilot-chat--shell-maker-get-buffer instance)
@@ -128,7 +128,7 @@ Argument CONTENT is copilot chat answer."
 (defun copilot-chat--shell-cb-prompt-wrapper (shell instance content)
   "Wrapper around `copilot-chat--shell-cb-prompt'.
 Argument SHELL is the `shell-maker' instance.
-Argument INSTANCE is copilot-chat instance.
+Argument INSTANCE is `copilot-chat' instance.
 Argument CONTENT is copilot chat answer."
   (if copilot-chat-follow
       (copilot-chat--shell-cb-prompt instance shell content)
@@ -137,7 +137,7 @@ Argument CONTENT is copilot chat answer."
 
 (defun copilot-chat--shell-cb (instance command shell)
   "Callback for Copilot Chat `shell-maker'.
-Argument INSTANCE is copilot-chat instance.
+Argument INSTANCE is `copilot-chat' instance.
 Argument COMMAND is the command to send to Copilot.
 Argument SHELL is the `shell-maker' instance."
   (setf

--- a/readme.org
+++ b/readme.org
@@ -21,7 +21,7 @@ You can now work with multiple chat instances at once. Copilot-chat instances ar
 - Model selection
 - Buffer list
 
-~Copilot-chat-display~ will try to guess the appropriate instance based on the current buffer's file location. If it fails, it will ask you to choose an instance. With a prefix argument (~C-u M-x copilot-chat-display~), it will always prompt you to select an instance.
+~copilot-chat-display~ (alias ~(copilot-chat)~) will try to guess the appropriate instance based on the current buffer's file location. If it fails, it will ask you to choose an instance. With a prefix argument (~C-u M-x copilot-chat-display~), it will always prompt you to select an instance.
 
 ** Help wanted
 Bug reports and new ideas are very welcome.
@@ -107,7 +107,7 @@ Proxies have not been thoroughly tested yet, so there may be bugs. Many options 
 
 * Usage
 ** Basic
-Start chatting with ~(copilot-chat-display)~. Type your question in prompt, then press ~C-c C-c~ or ~C-c RET~.
+Start chatting with ~(copilot-chat-display)~ (alias ~(copilot-chat)~). Type your question in prompt, then press ~C-c C-c~ or ~C-c RET~.
 You may need to authenticate to GitHub. Follow instructions.
 
 You can select buffers that will be added as context in your prompt. Use ~copilot-chat-add-current-buffer~ and ~copilot-chat-del-current-buffer~. You can also manage buffers by using ~(copilot-chat-list)~. In the list, selected buffer will be highlighted using ~copilot-chat-list-selected-buffer-face~ which inherit from ~font-lock-keyword-face~.
@@ -119,7 +119,7 @@ You can call ~(copilot-chat-transient)~ to open transient menu. Almost all funct
 
 ** Functions
 *** Basic functions
-- ~(copilot-chat-display)~ display copilot chat buffer. When using ~(copilot-chat-display)~ with a prefix argument, you'll be prompted to select which instance to use.
+- ~(copilot-chat-display)~ (alias ~(copilot-chat)~) display copilot chat buffer. When using ~(copilot-chat-display)~ with a prefix argument, you'll be prompted to select which instance to use.
 - ~(copilot-chat-reset)~ reset the current instance including history, frontend and included buffers (default). Use with prefix argument to preserve selected buffers.
 - ~(copilot-chat-switch-to-buffer)~ switch to Copilot Chat buffer, side by side with the current code editing buffer.
 - ~(copilot-chat-set-model)~ Select AI model to use for current instance.


### PR DESCRIPTION
`copilot-chat-display` is the most common starting command, is it not?

Can it take the alias `copilot-chat`?

I think this will help new users who intuitively look for a starting command, usually the name of the package.

------------

I have tested this by evaluating
```
(defalias 'copilot-chat 'copilot-chat-display)
```

The result is a new command:
```M-x copilot-chat```