### PR TITLE
fix: initialization of `copilot-chat-prompt` to empty closed #145

### DIFF
--- a/copilot-chat-prompts.el
+++ b/copilot-chat-prompts.el
@@ -205,7 +205,7 @@ Don't forget the most important rule when you are formatting your response: use 
   :type 'string
   :group 'copilot-chat)
 
-(defvar copilot-chat-prompt copilot-chat-org-prompt
+(defvar copilot-chat-prompt ""
   "The prompt to use for Copilot chat.")
 
 (provide 'copilot-chat-prompts)


### PR DESCRIPTION
Unlike before, now that instance separation has been reorganized,
the only place where `copilot-chat-prompt` is used is in `copilot-chat--create-req`.
That means initialization there is no longer strictly necessary,
so to avoid any mix‑ups, we’ll set the default value to an empty string.
Ideally, I’d like to split this field by natural language or frontend type,
but for now we’ll just solve the immediate problem.
