### PR TITLE
feat!: Add support `.github/git-commit-instructions.md` closed #160

### DIFF
--- a/copilot-chat-git.el
+++ b/copilot-chat-git.el
@@ -142,6 +142,7 @@ without creating a chat buffer or setting up a full chat environment."
     (let ((instance (copilot-chat--make
                      :directory current-dir
                      :model (or copilot-chat-commit-model copilot-chat-default-model)
+                     :type 'commit
                      :chat-buffer nil
                      :first-word-answer t
                      :history nil

--- a/copilot-chat-instance.el
+++ b/copilot-chat-instance.el
@@ -42,6 +42,7 @@ Use `copilot-chat-set-model' to interactively select a model."
   "Struct for Copilot chat state."
   (directory nil :type (or null string))
   (model copilot-chat-default-model :type string)
+  (type nil :type (or null symbol))
   (chat-buffer nil :type (or null buffer))
   (first-word-answer t :type boolean)
   (history nil :type list)

--- a/readme.org
+++ b/readme.org
@@ -217,6 +217,12 @@ Default prompts used by various commands:
 - ~copilot-chat-prompt-test~ - Prompt for test generation command.
 - ~copilot-chat-commit-prompt~ - Prompt for generating commit messages.
 
+*** Instruction Files
+Copilot Chat supports custom instructions from GitHub repository:
+- ~copilot-chat-use-copilot-instruction-files~ - Use custom instructions from ~.github/copilot-instructions.md~. Default is ~t~.
+- ~copilot-chat-use-git-commit-instruction-files~ - Use custom git commit instructions from ~.github/git-commit-instructions.md~. Default is ~t~.
+- ~copilot-chat-max-instruction-size~ - Maximum size in bytes of instruction files. Default is 65536 (64KB). Files exceeding this limit will be ignored. Set to ~nil~ for unlimited size.
+
 *** Git
 - ~copilot-chat-ignored-commit-files~ - List of file patterns to ignore when generating commit messages.
 


### PR DESCRIPTION
* Add config `copilot-chat-use-git-commit-instruction-files`
* Breaking Change from `copilot-chat-use-instruction-files` to `copilot-chat-use-copilot-instruction-files`
* To be generic for read file operation
* Read `.github/git-commit-instructions.md` file when commit
* Add `copilot-chat-type` for detecting git commit
