### PR TITLE
feat(ui): enhance buffer list display with path options

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -194,6 +194,8 @@ All variables can be customized using ~M-x customize-group RET copilot-chat RET~
 *** Display
 - ~copilot-chat-list-added-buffers-only~ - By default, buffer list displays all buffers and uses faces to highlight added buffer. If set to ~t~, only added buffer are displayed.
 - ~copilot-chat-follow~ - If ~t~ (default is ~nil~), point follows answer in chat buffer.
+- ~copilot-chat-list-show-path~ - If ~t~ (default), display file path in buffer list instead of buffer name.
+- ~copilot-chat-list-show-relative-path~ - If ~t~ (default), show only relative path in buffer list.
 
 *** Storage and cache
 - ~copilot-chat-github-token-file~ - File path to store GitHub authentication token.


### PR DESCRIPTION
- Add new customization variables to control path display:
  - Add copilot-chat-list-show-path to toggle full path display
  - Add copilot-chat-list-show-relative-path for relative/absolute path
- Update buffer list to respect these settings
- Add header line showing current directory
- Update documentation with new options

Fixes #154 