### PR TITLE
style: apply elisp-autofmt

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,3 +1,4 @@
 ((emacs-lisp-mode
+  (fill-column . 80)
   (indent-tabs-mode . nil)
   (package-lint-main-file . "copilot-chat.el")))

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,3 @@
+((emacs-lisp-mode
+  (indent-tabs-mode . nil)
+  (package-lint-main-file . "copilot-chat.el")))

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,4 +20,5 @@ jobs:
       - run: git diff --exit-code
       - uses: leotaku/elisp-check@v1.4.1
         with:
+          file: "copilot-chat*.el"
           warnings_as_errors: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,6 +14,10 @@ jobs:
       - uses: purcell/setup-emacs@v7.0
         with:
           version: 30.1
+      - run: git clone --depth=1 https://codeberg.org/ideasman42/emacs-elisp-autofmt.git
+      - run: chmod +x ./emacs-elisp-autofmt/elisp-autofmt.py
+      - run: git ls-files '*.el'|xargs -r ./emacs-elisp-autofmt/elisp-autofmt-cmd.py
+      - run: git diff --exit-code
       - uses: leotaku/elisp-check@v1.4.1
         with:
           warnings_as_errors: true

--- a/copilot-chat-body.el
+++ b/copilot-chat-body.el
@@ -163,8 +163,3 @@ The create req function is called first and will return new prompt."
 
 (provide 'copilot-chat-body)
 ;;; copilot-chat-body.el ends here
-
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; package-lint-main-file: "copilot-chat.el"
-;; End:

--- a/copilot-chat-body.el
+++ b/copilot-chat-body.el
@@ -44,9 +44,7 @@
 
 (defcustom copilot-chat-max-instruction-size 65536
   "Maximum size in bytes of instruction files."
-  :type '(choice
-          (const :tag "Unlimited" nil)
-          integer)
+  :type '(choice (const :tag "Unlimited" nil) integer)
   :group 'copilot-chat)
 
 (defun copilot-chat--read-instruction-file (file-name)
@@ -57,14 +55,17 @@ ignore it and emit a message."
          (github-dir (locate-dominating-file starting-path ".github"))
          (instruction-file
           (and github-dir
-               (expand-file-name (concat ".github/" file-name) github-dir))))
+               (expand-file-name (concat ".github/" file-name)
+                                 github-dir))))
     (when (and instruction-file (file-readable-p instruction-file))
       ;; Skip the file if it exceeds the configured size limit.
       (when (and copilot-chat-max-instruction-size
-                 (> (file-attribute-size (file-attributes instruction-file))
+                 (> (file-attribute-size
+                     (file-attributes instruction-file))
                     copilot-chat-max-instruction-size))
-        (message "[copilot-chat] `%s` is larger than %d bytes; ignored."
-                 instruction-file copilot-chat-max-instruction-size)
+        (message
+         "[copilot-chat] `%s` is larger than %d bytes; ignored."
+         instruction-file copilot-chat-max-instruction-size)
         (cl-return-from copilot-chat--read-instruction-file nil))
       (with-temp-buffer
         (insert-file-contents instruction-file)
@@ -78,23 +79,26 @@ ignore it and emit a message."
 (defun copilot-chat--read-git-commit-instructions-file ()
   "Return the content of `.github/git-commit-instructions.md' or nil."
   (when copilot-chat-use-git-commit-instruction-files
-    (copilot-chat--read-instruction-file "git-commit-instructions.md")))
+    (copilot-chat--read-instruction-file
+     "git-commit-instructions.md")))
 
 (defun copilot-chat--format-copilot-instructions (instruction-content)
   "Format instruction content according to Copilot's expected format.
 INSTRUCTION-CONTENT is the content read from the instructions file."
   (when instruction-content
-    (concat "When generating code, please follow these user provided coding instructions. "
-            "You can ignore an instruction if it contradicts a system message.\n\n"
-            "<instructions>\n"
-            instruction-content
-            "\n</instructions>")))
+    (concat
+     "When generating code, please follow these user provided coding instructions. "
+     "You can ignore an instruction if it contradicts a system message.\n\n"
+     "<instructions>\n"
+     instruction-content
+     "\n</instructions>")))
 
 (defun copilot-chat--format-buffer-for-copilot (buffer instance)
   "Format BUFFER content for Copilot with metadata to improve understanding.
 INSTANCE is the `copilot-chat' instance being used."
-  (let ((format-buffer-fn (copilot-chat-frontend-format-buffer-fn
-                           (copilot-chat--get-frontend))))
+  (let ((format-buffer-fn
+         (copilot-chat-frontend-format-buffer-fn
+          (copilot-chat--get-frontend))))
     (if format-buffer-fn
         (funcall format-buffer-fn buffer instance)
       (buffer-substring-no-properties (point-min) (point-max)))))
@@ -105,14 +109,16 @@ Argument INSTANCE is the copilot chat instance to use.
 Argument PROMPT Copilot prompt to send.
 Argument NO-CONTEXT tells `copilot-chat' to not send history and buffers.
 The create req function is called first and will return new prompt."
-  (let* ((create-req-fn (copilot-chat-frontend-create-req-fn
-                         (copilot-chat--get-frontend)))
+  (let* ((create-req-fn
+          (copilot-chat-frontend-create-req-fn
+           (copilot-chat--get-frontend)))
          (copilot-instruction-content
           (and copilot-chat-use-copilot-instruction-files
                (copilot-chat--read-copilot-instructions-file)))
          (formatted-copilot-instructions
           (and copilot-instruction-content
-               (copilot-chat--format-copilot-instructions copilot-instruction-content)))
+               (copilot-chat--format-copilot-instructions
+                copilot-instruction-content)))
          (git-commit-instruction-content
           (and copilot-chat-use-git-commit-instruction-files
                (copilot-chat--read-git-commit-instructions-file)))
@@ -126,26 +132,41 @@ The create req function is called first and will return new prompt."
     (unless no-context
       ;; history
       (dolist (history (copilot-chat-history instance))
-        (push (list `(content . ,(car history)) `(role . ,(cadr history))) messages))
+        (push (list
+               `(content . ,(car history)) `(role . ,(cadr history)))
+              messages))
       ;; Clean buffer list once and add buffer contents
       (setf (copilot-chat-buffers instance)
-            (cl-remove-if-not #'buffer-live-p (copilot-chat-buffers instance)))
+            (cl-remove-if-not
+             #'buffer-live-p (copilot-chat-buffers instance)))
       (dolist (buffer (copilot-chat-buffers instance))
         (when (buffer-live-p buffer)
-          (push (list `(content . ,(copilot-chat--format-buffer-for-copilot buffer instance))
-                      `(role . "user"))
+          (push (list
+                 `(content
+                   .
+                   ,(copilot-chat--format-buffer-for-copilot
+                     buffer instance))
+                 `(role . "user"))
                 messages))))
     ;; system.
     ;; Add custom instruction as a separate message if available.
     ;; Prefer Global < Project.
     (when formatted-copilot-instructions
-      (push (list `(content . ,formatted-copilot-instructions) `(role . "system")) messages))
+      (push (list
+             `(content . ,formatted-copilot-instructions)
+             `(role . "system"))
+            messages))
 
-    (when (and git-commit-instruction-content (eq (copilot-chat-type instance) 'commit))
-      (push (list `(content . ,git-commit-instruction-content) `(role . "system")) messages))
+    (when (and git-commit-instruction-content
+               (eq (copilot-chat-type instance) 'commit))
+      (push (list
+             `(content . ,git-commit-instruction-content)
+             `(role . "system"))
+            messages))
 
     ;; Global instruction.
-    (push (list `(content . ,copilot-chat-prompt) `(role . "system")) messages)
+    (push (list `(content . ,copilot-chat-prompt) `(role . "system"))
+          messages)
 
     ;; Create the appropriate payload based on model type
     (json-serialize

--- a/copilot-chat-command.el
+++ b/copilot-chat-command.el
@@ -872,8 +872,3 @@ displaying a file in the instance directory will be added."
 
 (provide 'copilot-chat-command)
 ;;; copilot-chat-command.el ends here
-
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; package-lint-main-file: "copilot-chat.el"
-;; End:

--- a/copilot-chat-command.el
+++ b/copilot-chat-command.el
@@ -55,31 +55,39 @@ If nil, show absolute path."
   '((t :inherit font-lock-keyword-face))
   "Face used for selected buffers in `copilot-chat' buffer list."
   :group 'copilot-chat)
-(defface copilot-chat-list-default-face
-  '((t :inherit default))
+(defface copilot-chat-list-default-face '((t :inherit default))
   "Face used for unselected buffers in `copilot-chat' buffer list."
   :group 'copilot-chat)
 
 ;; Variables
 (defvar copilot-chat-list-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "RET") 'copilot-chat-list-add-or-remove-buffer)
-    (define-key map (kbd "SPC") 'copilot-chat-list-add-or-remove-buffer)
+    (define-key
+     map (kbd "RET") 'copilot-chat-list-add-or-remove-buffer)
+    (define-key
+     map (kbd "SPC") 'copilot-chat-list-add-or-remove-buffer)
     (define-key map (kbd "C-c C-c") 'copilot-chat-list-clear-buffers)
-    (define-key map (kbd "g") (lambda()
-                                (interactive)
-                                (copilot-chat-list-refresh (copilot-chat--current-instance))))
-    (define-key map (kbd "q") (lambda()
-                                (interactive)
-                                (bury-buffer)
-                                (delete-window)))
+    (define-key
+     map (kbd "g")
+     (lambda ()
+       (interactive)
+       (copilot-chat-list-refresh (copilot-chat--current-instance))))
+    (define-key
+     map (kbd "q")
+     (lambda ()
+       (interactive)
+       (bury-buffer)
+       (delete-window)))
     map)
   "Keymap for `copilot-chat-list-mode'.")
 
 ;; Functions
-(define-derived-mode copilot-chat-list-mode special-mode "Copilot Chat List"
-  "Major mode for listing and managing buffers in Copilot chat."
-  (setq buffer-read-only t))
+(define-derived-mode
+ copilot-chat-list-mode
+ special-mode
+ "Copilot Chat List"
+ "Major mode for listing and managing buffers in Copilot chat."
+ (setq buffer-read-only t))
 
 (defun copilot-chat-prompt-send ()
   "Send the prompt content to Copilot.
@@ -92,12 +100,14 @@ to Copilot for processing."
       (let ((prompt (copilot-chat--pop-current-prompt instance)))
         (copilot-chat--write-buffer
          instance
-         (copilot-chat--format-data instance prompt 'prompt) nil)
+         (copilot-chat--format-data instance prompt 'prompt)
+         nil)
         (with-current-buffer (copilot-chat--get-buffer instance)
           (recenter-top-bottom))
         (push prompt (copilot-chat-prompt-history instance))
         (setf (copilot-chat-prompt-history-position instance) nil)
-        (copilot-chat--ask instance prompt 'copilot-chat-prompt-cb)))))
+        (copilot-chat--ask
+         instance prompt 'copilot-chat-prompt-cb)))))
 
 ;;;###autoload (autoload 'copilot-chat-ask-and-insert "copilot-chat" nil t)
 (defun copilot-chat-ask-and-insert ()
@@ -107,12 +117,11 @@ to Copilot for processing."
          (prompt (read-from-minibuffer "Copilot prompt: "))
          (current-buf (current-buffer)))
     (copilot-chat--ask
-     instance
-     prompt
+     instance prompt
      (lambda (instance content)
        (copilot-chat-prompt-cb instance content current-buf)))))
 
-(defun copilot-chat--ask-region(prompt beg end)
+(defun copilot-chat--ask-region (prompt beg end)
   "Send to Copilot a prompt followed by the current selected code.
 Argument PROMPT is the prompt to send to Copilot.
 BEG and END are the beginning and end positions of the region to explain."
@@ -120,8 +129,9 @@ BEG and END are the beginning and end positions of the region to explain."
         (code (buffer-substring-no-properties beg end)))
     (copilot-chat--insert-and-send-prompt
      instance
-     (concat (cdr (assoc prompt (copilot-chat--prompts)))
-             (copilot-chat--format-code code)))))
+     (concat
+      (cdr (assoc prompt (copilot-chat--prompts)))
+      (copilot-chat--format-code code)))))
 
 ;;;###autoload (autoload 'copilot-chat-explain "copilot-chat" nil t)
 (defun copilot-chat-explain (beg end)
@@ -169,8 +179,9 @@ BEG and END are the beginning and end positions of the region to test."
   "Insert PROMPT in the Copilot Chat prompt region.
 Argument INSTANCE is the copilot chat instance to use.
 Argument PROMPT is the text to insert in the prompt region."
-  (let ((prompt-fn (copilot-chat-frontend-insert-prompt-fn
-                    (copilot-chat--get-frontend))))
+  (let ((prompt-fn
+         (copilot-chat-frontend-insert-prompt-fn
+          (copilot-chat--get-frontend))))
     (when prompt-fn
       (funcall prompt-fn instance prompt))))
 
@@ -184,16 +195,20 @@ Argument PROMPT is the text to send to Copilot."
 (defun copilot-chat--get-language ()
   "Get the current language of the buffer.
 Derives language name from the major mode of the current buffer."
-  (if (derived-mode-p 'prog-mode)  ; current buffer is a programming language buffer
+  (if (derived-mode-p 'prog-mode) ; current buffer is a programming language buffer
       (let* ((major-mode-str (symbol-name major-mode))
-             (lang (replace-regexp-in-string "\\(?:-ts\\)?-mode$" "" major-mode-str)))
+             (lang
+              (replace-regexp-in-string
+               "\\(?:-ts\\)?-mode$" "" major-mode-str)))
         lang)
     nil))
 
-(defun copilot-chat--format-code(code)
+(defun copilot-chat--format-code (code)
   "Format code according to the frontend.
 Argument CODE is the code to be formatted."
-  (let ((format-fn (copilot-chat-frontend-format-code-fn (copilot-chat--get-frontend))))
+  (let ((format-fn
+         (copilot-chat-frontend-format-code-fn
+          (copilot-chat--get-frontend))))
     (if format-fn
         (funcall format-fn code (copilot-chat--get-language))
       code)))
@@ -203,13 +218,16 @@ Argument CODE is the code to be formatted."
   "Ask Copilot to explain symbol under point.
 Given the code line as background info."
   (interactive)
-  (let* ((instance (copilot-chat--current-instance))
-         (symbol (thing-at-point 'symbol))
-         (line (buffer-substring-no-properties
-                (line-beginning-position)
-                (line-end-position)))
-         (prompt (format "Please explain what '%s' means in the context of this code line:\n%s"
-                         symbol (copilot-chat--format-code line))))
+  (let*
+      ((instance (copilot-chat--current-instance))
+       (symbol (thing-at-point 'symbol))
+       (line
+        (buffer-substring-no-properties
+         (line-beginning-position) (line-end-position)))
+       (prompt
+        (format
+         "Please explain what '%s' means in the context of this code line:\n%s"
+         symbol (copilot-chat--format-code line))))
     (copilot-chat--insert-and-send-prompt instance prompt)))
 
 ;;;###autoload (autoload 'copilot-chat-explain-defun "copilot-chat" nil t)
@@ -235,8 +253,7 @@ Given the code line as background info."
   "Mark whole buffer, ask Copilot to review it, then unmark.
 It can be used to review the magit diff for my change, or other people's"
   (interactive)
-  (save-excursion
-    (copilot-chat-review (point-min) (point-max))))
+  (save-excursion (copilot-chat-review (point-min) (point-max))))
 
 ;;;###autoload (autoload 'copilot-chat-switch-to-buffer "copilot-chat" nil t)
 (defun copilot-chat-switch-to-buffer ()
@@ -244,8 +261,10 @@ It can be used to review the magit diff for my change, or other people's"
 Side by side with the current code editing buffer."
   (interactive)
   (let ((instance (copilot-chat--current-instance)))
-    (unless (equal (pm-base-buffer) (copilot-chat--get-buffer instance))
-      (switch-to-buffer-other-window (copilot-chat--get-buffer instance))))
+    (unless (equal
+             (pm-base-buffer) (copilot-chat--get-buffer instance))
+      (switch-to-buffer-other-window
+       (copilot-chat--get-buffer instance))))
   (copilot-chat-goto-input))
 
 ;;;###autoload (autoload 'copilot-chat-custom-prompt-selection "copilot-chat" nil t)
@@ -254,11 +273,16 @@ Side by side with the current code editing buffer."
 If CUSTOM-PROMPT is provided, use it instead of reading from the mini-buffer."
   (interactive)
   (let* ((instance (copilot-chat--current-instance))
-         (prompt (or custom-prompt (read-from-minibuffer "Copilot prompt: ")))
-         (code (if (use-region-p)
-                   (buffer-substring-no-properties (region-beginning) (region-end))
-                 (buffer-substring-no-properties (point-min) (point-max))))
-         (formatted-prompt (concat prompt "\n" (copilot-chat--format-code code))))
+         (prompt
+          (or custom-prompt
+              (read-from-minibuffer "Copilot prompt: ")))
+         (code
+          (if (use-region-p)
+              (buffer-substring-no-properties
+               (region-beginning) (region-end))
+            (buffer-substring-no-properties (point-min) (point-max))))
+         (formatted-prompt
+          (concat prompt "\n" (copilot-chat--format-code code))))
     (copilot-chat--insert-and-send-prompt instance formatted-prompt)))
 
 ;;;###autoload (autoload 'copilot-chat-custom-prompt-mini-buffer "copilot-chat" nil t)
@@ -267,7 +291,8 @@ If CUSTOM-PROMPT is provided, use it instead of reading from the mini-buffer."
   (interactive)
   (let* ((instance (copilot-chat--current-instance))
          (prompt "Question for copilot-chat: ")
-         (input (read-string prompt nil 'copilot-chat--prompt-history)))
+         (input
+          (read-string prompt nil 'copilot-chat--prompt-history)))
     (copilot-chat--insert-and-send-prompt instance input)))
 
 ;;;###autoload (autoload 'copilot-chat-list "copilot-chat" nil t)
@@ -285,22 +310,26 @@ If CUSTOM-PROMPT is provided, use it instead of reading from the mini-buffer."
   "Internal function to display copilot chat buffer.
 Argument INSTANCE is the copilot chat instance to display."
   (let ((base-buffer (copilot-chat--get-buffer instance))
-        (init-fn (copilot-chat-frontend-init-fn
-                  (copilot-chat--get-frontend)))
+        (init-fn
+         (copilot-chat-frontend-init-fn (copilot-chat--get-frontend)))
         (window-found nil))
     (when init-fn
       (funcall init-fn))
     ;; Check if any window is already displaying the base buffer or an indirect
     ;; buffer
-    (cl-block window-search
-      (dolist (window (window-list))
-        (let ((buf (window-buffer window)))
-          (when (or (eq buf base-buffer)
-                    (eq (with-current-buffer buf (pm-base-buffer)) base-buffer))
-            (select-window window)
-            (switch-to-buffer base-buffer)
-            (setq window-found t)
-            (cl-return-from window-search)))))
+    (cl-block
+     window-search
+     (dolist (window (window-list))
+       (let ((buf (window-buffer window)))
+         (when (or (eq buf base-buffer)
+                   (eq
+                    (with-current-buffer buf
+                      (pm-base-buffer))
+                    base-buffer))
+           (select-window window)
+           (switch-to-buffer base-buffer)
+           (setq window-found t)
+           (cl-return-from window-search)))))
 
     (unless window-found
       (pop-to-buffer base-buffer))))
@@ -311,9 +340,10 @@ Argument INSTANCE is the copilot chat instance to display."
 With prefix argument, explicitly ask for which instance to use.
 Optional argument ARG if non-nil, force instance selection."
   (interactive "P")
-  (let ((instance (if arg
-                      (copilot-chat--ask-for-instance)
-                    (copilot-chat--current-instance))))
+  (let ((instance
+         (if arg
+             (copilot-chat--ask-for-instance)
+           (copilot-chat--current-instance))))
     (copilot-chat--display instance)))
 
 ;;;###autoload (autoload 'copilot-chat "copilot-chat" nil t)
@@ -328,7 +358,10 @@ Optional argument ARG if non-nil, force instance selection."
     (dolist (window (window-list))
       (let ((buf (window-buffer window)))
         (when (or (eq buf base-buffer)
-                  (eq (with-current-buffer buf (pm-base-buffer)) base-buffer))
+                  (eq
+                   (with-current-buffer buf
+                     (pm-base-buffer))
+                   base-buffer))
           (delete-window window))))))
 
 (defun copilot-chat-add-current-buffer ()
@@ -347,27 +380,26 @@ Optional argument ARG if non-nil, force instance selection."
 
 (defun copilot-chat-add-buffers (buffers)
   "Add BUFFERS to sent buffers list."
-  (interactive
-   (list (completing-read-multiple "Buffers: "
-                                   (mapcar #'buffer-name (buffer-list))
-                                   nil t (buffer-name (current-buffer)))))
+  (interactive (list
+                (completing-read-multiple
+                 "Buffers: "
+                 (mapcar #'buffer-name (buffer-list)) nil t
+                 (buffer-name (current-buffer)))))
   (let ((instance (copilot-chat--current-instance)))
-    (mapc (lambda (buf)
-            (copilot-chat--add-buffer instance buf))
-          buffers)
+    (mapc
+     (lambda (buf) (copilot-chat--add-buffer instance buf)) buffers)
     (copilot-chat-list-refresh instance)))
 
 (defun copilot-chat-del-buffers (buffers)
   "Remove BUFFERS from sent buffers list."
-  (interactive
-   (list
-    (completing-read-multiple "Buffers: "
-                              (mapcar #'buffer-name (buffer-list))
-                              nil t (buffer-name (current-buffer)))))
+  (interactive (list
+                (completing-read-multiple
+                 "Buffers: "
+                 (mapcar #'buffer-name (buffer-list)) nil t
+                 (buffer-name (current-buffer)))))
   (let ((instance (copilot-chat--current-instance)))
-    (mapc (lambda (buf)
-            (copilot-chat--del-buffer instance buf))
-          buffers)
+    (mapc
+     (lambda (buf) (copilot-chat--del-buffer instance buf)) buffers)
     (copilot-chat-list-refresh instance)))
 
 (defun copilot-chat-add-file (file-path)
@@ -400,27 +432,34 @@ If there are more than 40 files, refuse to add and show warning message."
     (let* ((current-suffix (file-name-extension buffer-file-name))
            (dir (file-name-directory buffer-file-name))
            (max-files 40)
-           (files (directory-files dir t
-                                   (concat "\\." current-suffix "$")
-                                   t))) ; t means don't include . and ..
+           (files
+            (directory-files dir
+                             t (concat "\\." current-suffix "$")
+                             t))) ; t means don't include . and ..
       (if (> (length files) max-files)
-          (message "Too many files (%d, > %d) found with suffix .%s. Aborting."
-                   (length files) max-files current-suffix)
+          (message
+           "Too many files (%d, > %d) found with suffix .%s. Aborting."
+           (length files) max-files current-suffix)
         (dolist (file files)
           (copilot-chat-add-file file))
         (message "Added %d files with suffix .%s"
-                 (length files) current-suffix)))))
+                 (length files)
+                 current-suffix)))))
 
 (defun copilot-chat--buffer-list (instance)
   "Return a list of buffer with files in INSTANCE directory."
   (let* ((dir (copilot-chat-directory instance))
-         (bufs-under-dir (cl-remove-if-not
-                          (lambda (buf)
-                            (with-current-buffer buf
-                              (and buffer-file-name
-                                   (file-in-directory-p buffer-file-name dir))))
-                          (buffer-list))))
-    (cl-union bufs-under-dir (copilot-chat-buffers instance) :test #'eq)))
+         (bufs-under-dir
+          (cl-remove-if-not
+           (lambda (buf)
+             (with-current-buffer buf
+               (and buffer-file-name
+                    (file-in-directory-p buffer-file-name dir))))
+           (buffer-list))))
+    (cl-union
+     bufs-under-dir
+     (copilot-chat-buffers instance)
+     :test #'eq)))
 
 (defun copilot-chat-list-refresh (&optional instance)
   "Refresh the list of buffers in the current Copilot chat list buffer.
@@ -429,36 +468,46 @@ Optional argument INSTANCE specifies which instance to refresh the list for."
   (unless instance
     (setq instance (copilot-chat--current-instance)))
   (setf (copilot-chat-buffers instance)
-        (cl-remove-if-not #'buffer-live-p (copilot-chat-buffers instance)))
+        (cl-remove-if-not
+         #'buffer-live-p (copilot-chat-buffers instance)))
   (with-current-buffer (copilot-chat--get-list-buffer-create instance)
     (let* ((pt (point))
            (inhibit-read-only t)
-           (buffers (if copilot-chat-list-added-buffers-only
-                        (copilot-chat-buffers instance)
-                      (copilot-chat--buffer-list instance)))
+           (buffers
+            (if copilot-chat-list-added-buffers-only
+                (copilot-chat-buffers instance)
+              (copilot-chat--buffer-list instance)))
            (sorted-buffers
             (sort buffers
                   (lambda (a b)
-                    (string< (symbol-name (buffer-local-value 'major-mode a))
-                             (symbol-name (buffer-local-value 'major-mode b)))))))
+                    (string<
+                     (symbol-name (buffer-local-value 'major-mode a))
+                     (symbol-name
+                      (buffer-local-value 'major-mode b)))))))
       (erase-buffer)
-      (setq-local header-line-format (concat "Copilot chat " (copilot-chat-directory instance)))
+      (setq-local header-line-format
+                  (concat
+                   "Copilot chat " (copilot-chat-directory instance)))
       (dolist (buffer sorted-buffers)
         (let* ((file-name (buffer-file-name buffer))
-               (buffer-name (if (and file-name copilot-chat-list-show-path)
-                                (if copilot-chat-list-show-relative-path
-                                    (file-relative-name file-name
-                                                        (copilot-chat-directory instance))
-                                  file-name)
-                              (buffer-name buffer)))
+               (buffer-name
+                (if (and file-name copilot-chat-list-show-path)
+                    (if copilot-chat-list-show-relative-path
+                        (file-relative-name file-name
+                                            (copilot-chat-directory
+                                             instance))
+                      file-name)
+                  (buffer-name buffer)))
                (cop-bufs (copilot-chat--get-buffers instance)))
           (when (and (not (string-prefix-p " " buffer-name))
                      (not (string-prefix-p "*" buffer-name)))
-            (insert (propertize buffer-name
-                                'face (if (member buffer cop-bufs)
-                                          'copilot-chat-list-selected-buffer-face
-                                        'copilot-chat-list-default-face))
-                    "\n"))))
+            (insert
+             (propertize buffer-name
+                         'face
+                         (if (member buffer cop-bufs)
+                             'copilot-chat-list-selected-buffer-face
+                           'copilot-chat-list-default-face))
+             "\n"))))
       (goto-char pt))))
 
 
@@ -466,24 +515,30 @@ Optional argument INSTANCE specifies which instance to refresh the list for."
   "Add or remove the buffer at point from the Copilot chat list."
   (interactive)
   (let* ((instance (copilot-chat--current-instance))
-         (buffer-name (buffer-substring (line-beginning-position)
-                                        (line-end-position)))
-         (buffer (if copilot-chat-list-show-path
-                     (or (get-file-buffer
-                          (if copilot-chat-list-show-relative-path
-                              (concat (copilot-chat-directory instance)
-                                      "/" buffer-name)
-                            buffer-name))
-                         (get-buffer buffer-name))
-                     (get-buffer buffer-name)))
+         (buffer-name
+          (buffer-substring
+           (line-beginning-position) (line-end-position)))
+         (buffer
+          (if copilot-chat-list-show-path
+              (or (get-file-buffer
+                   (if copilot-chat-list-show-relative-path
+                       (concat
+                        (copilot-chat-directory instance)
+                        "/"
+                        buffer-name)
+                     buffer-name))
+                  (get-buffer buffer-name))
+            (get-buffer buffer-name)))
          (cop-bufs (copilot-chat--get-buffers instance)))
     (when buffer
       (if (member buffer cop-bufs)
           (progn
             (copilot-chat--del-buffer instance buffer)
-            (message "Buffer '%s' removed from Copilot chat list." buffer-name))
+            (message "Buffer '%s' removed from Copilot chat list."
+                     buffer-name))
         (copilot-chat--add-buffer instance buffer)
-        (message "Buffer '%s' added to Copilot chat list." buffer-name)))
+        (message "Buffer '%s' added to Copilot chat list."
+                 buffer-name)))
     (copilot-chat-list-refresh instance)))
 
 (defun copilot-chat-list-clear-buffers ()
@@ -494,7 +549,7 @@ Optional argument INSTANCE specifies which instance to refresh the list for."
     (message "Cleared all buffers from Copilot chat list.")
     (copilot-chat-list-refresh instance)))
 
-(defun copilot-chat-prompt-split-and-list()
+(defun copilot-chat-prompt-split-and-list ()
   "Split prompt window and display buffer list."
   (interactive)
   (let ((split-window-preferred-function nil)
@@ -504,42 +559,53 @@ Optional argument INSTANCE specifies which instance to refresh the list for."
   (other-window 1)
   (copilot-chat-list))
 
-(defun copilot-chat-prompt-history-previous()
+(defun copilot-chat-prompt-history-previous ()
   "Insert previous prompt in prompt buffer."
   (interactive)
   (let* ((instance (copilot-chat--current-instance))
-         (prompt (if (null (copilot-chat-prompt-history instance))
-                     nil
-                   (if (null (copilot-chat-prompt-history-position instance))
-                       (progn
-                         (setf (copilot-chat-prompt-history-position instance) 0)
-                         (car (copilot-chat-prompt-history instance)))
-                     (if (= (copilot-chat-prompt-history-position instance)
-                            (1- (length (copilot-chat-prompt-history instance))))
-                         (car (last (copilot-chat-prompt-history instance)))
-                       (setf (copilot-chat-prompt-history-position instance)
-                             (1+ (copilot-chat-prompt-history-position instance)))
-                       (nth (copilot-chat-prompt-history-position instance)
-                            (copilot-chat-prompt-history instance)))))))
+         (prompt
+          (if (null (copilot-chat-prompt-history instance))
+              nil
+            (if (null (copilot-chat-prompt-history-position instance))
+                (progn
+                  (setf (copilot-chat-prompt-history-position
+                         instance)
+                        0)
+                  (car (copilot-chat-prompt-history instance)))
+              (if (= (copilot-chat-prompt-history-position instance)
+                     (1- (length
+                          (copilot-chat-prompt-history instance))))
+                  (car (last (copilot-chat-prompt-history instance)))
+                (setf (copilot-chat-prompt-history-position instance)
+                      (1+ (copilot-chat-prompt-history-position
+                           instance)))
+                (nth
+                 (copilot-chat-prompt-history-position instance)
+                 (copilot-chat-prompt-history instance)))))))
     (when prompt
       (copilot-chat--insert-prompt instance prompt))))
 
 
-(defun copilot-chat-prompt-history-next()
+(defun copilot-chat-prompt-history-next ()
   "Insert next prompt in prompt buffer."
   (interactive)
   (let* ((instance (copilot-chat--current-instance))
-         (prompt (if (null (copilot-chat-prompt-history instance))
-                     nil
-                   (if (null (copilot-chat-prompt-history-position instance))
-                       nil
-                     (if (= 0 (copilot-chat-prompt-history-position instance))
-                         ""
-                       (progn
-                         (setf (copilot-chat-prompt-history-position instance)
-                               (1- (copilot-chat-prompt-history-position instance)))
-                         (nth (copilot-chat-prompt-history-position instance)
-                              (copilot-chat-prompt-history instance))))))))
+         (prompt
+          (if (null (copilot-chat-prompt-history instance))
+              nil
+            (if (null (copilot-chat-prompt-history-position instance))
+                nil
+              (if (= 0
+                     (copilot-chat-prompt-history-position instance))
+                  ""
+                (progn
+                  (setf (copilot-chat-prompt-history-position
+                         instance)
+                        (1- (copilot-chat-prompt-history-position
+                             instance)))
+                  (nth
+                   (copilot-chat-prompt-history-position instance)
+                   (copilot-chat-prompt-history instance))))))))
     (when prompt
       (copilot-chat--insert-prompt instance prompt))))
 
@@ -549,54 +615,63 @@ When called interactively with prefix argument, preserve the buffer list.
 Optional argument KEEP-BUFFERS if non-nil, preserve the current buffer list."
   (interactive "P")
   (let* ((instance (copilot-chat--current-instance))
-         (old-buffers (when keep-buffers
-                        (copilot-chat-buffers instance)))
+         (old-buffers
+          (when keep-buffers
+            (copilot-chat-buffers instance)))
          (buf (copilot-chat--get-buffer instance)))
     (when (buffer-live-p buf)
       (kill-buffer buf))
-    (setf (copilot-chat-history instance) nil
-          (copilot-chat-prompt-history instance) nil
-          (copilot-chat-prompt-history-position instance) nil
-          (copilot-chat-yank-index instance) 1
-          (copilot-chat-last-yank-start instance) nil
-          (copilot-chat-last-yank-end instance) nil
-          (copilot-chat-spinner-timer instance) nil
-          (copilot-chat-spinner-index instance) 0
-          (copilot-chat-spinner-status instance) nil)
+    (setf
+     (copilot-chat-history instance) nil
+     (copilot-chat-prompt-history instance) nil
+     (copilot-chat-prompt-history-position instance) nil
+     (copilot-chat-yank-index instance) 1
+     (copilot-chat-last-yank-start instance) nil
+     (copilot-chat-last-yank-end instance) nil
+     (copilot-chat-spinner-timer instance) nil
+     (copilot-chat-spinner-index instance) 0
+     (copilot-chat-spinner-status instance) nil)
     (unless old-buffers
       (setf (copilot-chat-buffers instance) nil))
     (copilot-chat--display instance)
     (copilot-chat-list-refresh instance)))
 
-(defun copilot-chat--clean()
+(defun copilot-chat--clean ()
   "Cleaning function."
-  (let ((clean-fn (copilot-chat-frontend-clean-fn (copilot-chat--get-frontend))))
+  (let ((clean-fn
+         (copilot-chat-frontend-clean-fn
+          (copilot-chat--get-frontend))))
     (when clean-fn
       (funcall clean-fn))))
 
 
-(defun copilot-chat-send-to-buffer()
+(defun copilot-chat-send-to-buffer ()
   "Send the code block at point to buffer.
 Replace selection if any."
   (interactive)
-  (let ((send-fn (copilot-chat-frontend-send-to-buffer-fn
-                  (copilot-chat--get-frontend))))
+  (let ((send-fn
+         (copilot-chat-frontend-send-to-buffer-fn
+          (copilot-chat--get-frontend))))
     (when send-fn
       (funcall send-fn))))
 
 (defun copilot-chat-copy-code-at-point ()
   "Copy the code block at point into kill ring."
   (interactive)
-  (let ((copy-fn (copilot-chat-frontend-copy-fn (copilot-chat--get-frontend))))
+  (let ((copy-fn
+         (copilot-chat-frontend-copy-fn
+          (copilot-chat--get-frontend))))
     (when copy-fn
       (funcall copy-fn))))
 
-(defun copilot-chat-goto-input()
+(defun copilot-chat-goto-input ()
   "Go to the input area."
   (interactive)
   (let ((instance (copilot-chat--current-instance)))
     (when (equal (pm-base-buffer) (copilot-chat--get-buffer instance))
-      (let ((goto-fn (copilot-chat-frontend-goto-input-fn (copilot-chat--get-frontend))))
+      (let ((goto-fn
+             (copilot-chat-frontend-goto-input-fn
+              (copilot-chat--get-frontend))))
         (when goto-fn
           (funcall goto-fn))))))
 
@@ -611,8 +686,7 @@ for most people nowadays than GPT-4o."
 The model is enabled if it has no policy or if its policy state is \"enabled\".
 This function checks the JSON policy data returned from the API."
   (let ((policy (alist-get 'policy model)))
-    (or (not policy)
-        (equal (alist-get 'state policy) "enabled"))))
+    (or (not policy) (equal (alist-get 'state policy) "enabled"))))
 
 (defun copilot-chat--get-model-choices-with-wait ()
   "Get the list of available models for Copilot Chat.
@@ -620,96 +694,131 @@ waiting for fetch if needed.
 If models haven't been fetched yet and no cache exists,
 wait for the fetch to complete."
   (let ((models
-         (seq-filter #'copilot-chat--model-enabled-p
-                     (if copilot-chat-model-ignore-picker
-                         (copilot-chat-connection-models copilot-chat--connection)
-                       (seq-filter #'copilot-chat--model-picker-enabled
-                                   (copilot-chat-connection-models
-                                    copilot-chat--connection))))))
+         (seq-filter
+          #'copilot-chat--model-enabled-p
+          (if copilot-chat-model-ignore-picker
+              (copilot-chat-connection-models
+               copilot-chat--connection)
+            (seq-filter
+             #'copilot-chat--model-picker-enabled
+             (copilot-chat-connection-models
+              copilot-chat--connection))))))
     (if models
         (let* ((model-info-list
                 (mapcar
                  (lambda (model)
                    (let* ((id (alist-get 'id model))
                           (name (alist-get 'name model))
-                          (clean-name (replace-regexp-in-string " (Preview)$" "" name))
+                          (clean-name
+                           (replace-regexp-in-string
+                            " (Preview)$" "" name))
                           (vendor (alist-get 'vendor model))
-                          (capabilities (alist-get 'capabilities model))
+                          (capabilities
+                           (alist-get 'capabilities model))
                           (limits (alist-get 'limits capabilities))
-                          (preview-p (eq t (alist-get 'preview model)))
-                          (preview-text (if preview-p " (Preview)" ""))
-                          (prompt-tokens (alist-get 'max_prompt_tokens limits))
-                          (output-tokens (or (alist-get 'max_output_tokens limits)
-                                             (when (string-prefix-p "o1" id) 100000)))
-                          (prompt-text (if prompt-tokens
-                                           (format "%dk" (round (/ prompt-tokens 1000)))
-                                         "?"))
-                          (output-text (if output-tokens
-                                           (format "%dk" (round (/ output-tokens 1000)))
-                                         "?")))
-                     (list :id id
-                           :vendor vendor
-                           :clean-name clean-name
-                           :preview-text preview-text
-                           :prompt-text prompt-text
-                           :output-text output-text)))
+                          (preview-p
+                           (eq t (alist-get 'preview model)))
+                          (preview-text
+                           (if preview-p
+                               " (Preview)"
+                             ""))
+                          (prompt-tokens
+                           (alist-get 'max_prompt_tokens limits))
+                          (output-tokens
+                           (or (alist-get 'max_output_tokens limits)
+                               (when (string-prefix-p "o1" id)
+                                 100000)))
+                          (prompt-text
+                           (if prompt-tokens
+                               (format "%dk"
+                                       (round (/ prompt-tokens 1000)))
+                             "?"))
+                          (output-text
+                           (if output-tokens
+                               (format "%dk"
+                                       (round (/ output-tokens 1000)))
+                             "?")))
+                     (list
+                      :id id
+                      :vendor vendor
+                      :clean-name clean-name
+                      :preview-text preview-text
+                      :prompt-text prompt-text
+                      :output-text output-text)))
                  models))
                (max-vendor-width
                 (apply #'max
-                       (mapcar (lambda (info)
-                                 (length (plist-get info :vendor))) model-info-list)))
+                       (mapcar
+                        (lambda (info)
+                          (length (plist-get info :vendor)))
+                        model-info-list)))
                (max-name-width
                 (apply #'max
-                       (mapcar (lambda (info)
-                                 (length (plist-get info :clean-name))) model-info-list)))
+                       (mapcar
+                        (lambda (info)
+                          (length (plist-get info :clean-name)))
+                        model-info-list)))
                (max-preview-width
                 (apply #'max
-                       (mapcar (lambda (info)
-                                 (length (plist-get info :preview-text))) model-info-list)))
+                       (mapcar
+                        (lambda (info)
+                          (length (plist-get info :preview-text)))
+                        model-info-list)))
                (max-prompt-width
                 (apply #'max
-                       (mapcar (lambda (info)
-                                 (length (plist-get info :prompt-text))) model-info-list)))
+                       (mapcar
+                        (lambda (info)
+                          (length (plist-get info :prompt-text)))
+                        model-info-list)))
                (max-output-width
                 (apply #'max
-                       (mapcar (lambda (info)
-                                 (length (plist-get info :output-text))) model-info-list)))
-               (format-str (format "[%%-%ds] %%-%ds%%-%ds (Tokens in/out: %%%ds/%%%ds)"
-                                   max-vendor-width
-                                   max-name-width
-                                   max-preview-width
-                                   max-prompt-width
-                                   max-output-width)))
+                       (mapcar
+                        (lambda (info)
+                          (length (plist-get info :output-text)))
+                        model-info-list)))
+               (format-str
+                (format
+                 "[%%-%ds] %%-%ds%%-%ds (Tokens in/out: %%%ds/%%%ds)"
+                 max-vendor-width
+                 max-name-width
+                 max-preview-width
+                 max-prompt-width
+                 max-output-width)))
           ;; Return list of (name . id) pairs from fetched models, sorted by ID
-          (sort
-           (mapcar (lambda (info)
-                     (cons
-                      (format format-str
-                              (plist-get info :vendor)
-                              (plist-get info :clean-name)
-                              (plist-get info :preview-text)
-                              (plist-get info :prompt-text)
-                              (plist-get info :output-text))
-                      (plist-get info :id)))
-                   model-info-list)
-           (lambda (a b) (string< (cdr a) (cdr b)))))
+          (sort (mapcar
+                 (lambda (info)
+                   (cons
+                    (format format-str
+                            (plist-get info :vendor)
+                            (plist-get info :clean-name)
+                            (plist-get info :preview-text)
+                            (plist-get info :prompt-text)
+                            (plist-get info :output-text))
+                    (plist-get info :id)))
+                 model-info-list)
+                (lambda (a b) (string< (cdr a) (cdr b)))))
       ;; No models available - fetch and wait
       (progn
         ;; Try loading from cache first
         (let ((cached-models (copilot-chat--load-models-from-cache)))
           (if cached-models
               (progn
-                (setf (copilot-chat-connection-models copilot-chat--connection)
+                (setf (copilot-chat-connection-models
+                       copilot-chat--connection)
                       cached-models)
                 (copilot-chat--get-model-choices-with-wait))
             ;; No cache - need to fetch
             (message "No models available. Fetching from API...")
             (copilot-chat--auth)
-            (let ((inhibit-quit t))  ; Prevent C-g during fetch
+            (let ((inhibit-quit t)) ; Prevent C-g during fetch
               (copilot-chat--request-models t)
               ;; Wait for models to be fetched (with timeout)
-              (with-timeout (10 (error "Timeout waiting for models to be fetched"))
-                (while (not (copilot-chat-connection-models copilot-chat--connection))
+              (with-timeout
+                  (10
+                   (error "Timeout waiting for models to be fetched"))
+                (while (not
+                        (copilot-chat-connection-models
+                         copilot-chat--connection))
                   (sit-for 0.1)))
               (copilot-chat--get-model-choices-with-wait))))))))
 
@@ -718,24 +827,28 @@ wait for the fetch to complete."
   "Set the Copilot Chat model to MODEL for the current instance.
 Fetches available models from the API if not already fetched."
   (interactive
-   (let* ((choices (copilot-chat--get-model-choices-with-wait))
-          (max-id-width
-           (apply #'max
-                  (mapcar (lambda (choics)
-                            (length (cdr choics))) choices)))
-          ;; Create completion list with ID as prefix for unique identification
-          (completion-choices
-           (mapcar (lambda (choice)
-                     (let ((name (car choice))
-                           (id (cdr choice)))
-                       (cons (format (format "[%%-%ds] %%s" max-id-width)
-                                     id name)
-                             id)))
-                   choices))
-          (choice
-           (completing-read "Select Copilot Chat model: "
-                            (mapcar 'car completion-choices)
-                            nil t)))
+   (let*
+       ((choices (copilot-chat--get-model-choices-with-wait))
+        (max-id-width
+         (apply #'max
+                (mapcar
+                 (lambda (choics) (length (cdr choics))) choices)))
+        ;; Create completion list with ID as prefix for unique identification
+        (completion-choices
+         (mapcar
+          (lambda (choice)
+            (let ((name (car choice))
+                  (id (cdr choice)))
+              (cons
+               (format (format "[%%-%ds] %%s" max-id-width)
+                       id name)
+               id)))
+          choices))
+        (choice
+         (completing-read "Select Copilot Chat model: "
+                          (mapcar 'car completion-choices)
+                          nil
+                          t)))
      ;; Extract model ID from the selected choice
      (let ((model-value (cdr (assoc choice completion-choices))))
        (when copilot-chat-debug
@@ -745,9 +858,10 @@ Fetches available models from the API if not already fetched."
   ;; Set the model value only for current instance
   (let ((instance (copilot-chat--current-instance)))
     (setf (copilot-chat-model instance) model)
-    (message "Copilot Chat model set to %s for current instance" model)))
+    (message "Copilot Chat model set to %s for current instance"
+             model)))
 
-(defun copilot-chat-yank()
+(defun copilot-chat-yank ()
   "Insert last code block given by `copilot-chat'."
   (interactive)
   (let ((instance (copilot-chat--current-instance)))
@@ -757,7 +871,7 @@ Fetches available models from the API if not already fetched."
      (copilot-chat-last-yank-end instance) nil)
     (copilot-chat--yank instance)))
 
-(defun copilot-chat-yank-pop(&optional inc)
+(defun copilot-chat-yank-pop (&optional inc)
   "Replace just-yanked code block with a different block.
 INC is the number to use as increment for index in block ring."
   (interactive "*p")
@@ -773,10 +887,12 @@ INC is the number to use as increment for index in block ring."
     (copilot-chat--yank instance)
     (setq this-command 'copilot-chat-yank-pop)))
 
-(defun copilot-chat--yank(instance)
+(defun copilot-chat--yank (instance)
   "Insert at point the code block at the current index in the block ring.
 Argument INSTANCE is the copilot chat instance to use."
-  (when-let* ((yank-fn (copilot-chat-frontend-yank-fn (copilot-chat--get-frontend))))
+  (when-let* ((yank-fn
+               (copilot-chat-frontend-yank-fn
+                (copilot-chat--get-frontend))))
     (funcall yank-fn instance)))
 
 ;;;###autoload (autoload 'copilot-chat-clear-auth-cache "copilot-chat" nil t)
@@ -786,7 +902,8 @@ Argument INSTANCE is the copilot chat instance to use."
   (copilot-chat-reset)
   ;; remove copilot-chat-token-cache file
   (let ((token-cache-file (expand-file-name copilot-chat-token-cache))
-        (github-token-file (expand-file-name copilot-chat-github-token-file)))
+        (github-token-file
+         (expand-file-name copilot-chat-github-token-file)))
     (when (file-exists-p token-cache-file)
       (delete-file token-cache-file))
     (when (file-exists-p github-token-file)
@@ -802,10 +919,13 @@ Clears model cache from memory and disk, then triggers background fetch."
   (interactive)
   ;; Clear models
   (setf (copilot-chat-connection-models copilot-chat--connection) nil)
-  (setf (copilot-chat-connection-last-models-fetch-time copilot-chat--connection) 0)
+  (setf (copilot-chat-connection-last-models-fetch-time
+         copilot-chat--connection)
+        0)
 
   ;; Remove cached models file if it exists
-  (let ((models-cache-file (expand-file-name copilot-chat-models-cache-file)))
+  (let ((models-cache-file
+         (expand-file-name copilot-chat-models-cache-file)))
     (when (file-exists-p models-cache-file)
       (delete-file models-cache-file)
       (when copilot-chat-debug
@@ -818,34 +938,33 @@ Clears model cache from memory and disk, then triggers background fetch."
   ;; Return nil for programmatic usage
   nil)
 
-(aio-defun copilot-chat--add-workspace (instance only-open)
-  "Add all files matching an instance to buffer list.
+(aio-defun
+ copilot-chat--add-workspace (instance only-open)
+ "Add all files matching an instance to buffer list.
 INSTANCE is the copilot chat instance to use.  If ONLY-OPEN is non-nil,
 add only files already visited by a buffer."
-  (copilot-chat--clear-buffers instance)
-  (let* ((default-directory (copilot-chat-directory instance))
-         (repo-root (aio-await (copilot-chat--git-top-level)))
-         (files (if (null repo-root)
-                    (directory-files-recursively default-directory ".*" nil)
-                  (aio-await (copilot-chat--git-ls-files repo-root))))
-         (file-count (length files)))
-    (if (and (> file-count 50)
-             (not only-open)
-             (not (yes-or-no-p (format "Found %d files, add them all? "
-                                       file-count))))
-        (message "Workspace file addition cancelled.")
-      (if only-open
-          (mapcar
-           (lambda (buffer)
-             (let ((file (buffer-file-name buffer)))
-               (when (and file
-                          (member (expand-file-name file) files))
-                 (copilot-chat--add-buffer instance buffer))))
-           (buffer-list))
-        (mapcar
-         (lambda (file)
-           (copilot-chat-add-file file))
-         files)))))
+ (copilot-chat--clear-buffers instance)
+ (let* ((default-directory (copilot-chat-directory instance))
+        (repo-root (aio-await (copilot-chat--git-top-level)))
+        (files
+         (if (null repo-root)
+             (directory-files-recursively default-directory ".*" nil)
+           (aio-await (copilot-chat--git-ls-files repo-root))))
+        (file-count (length files)))
+   (if (and (> file-count 50)
+            (not only-open)
+            (not
+             (yes-or-no-p
+              (format "Found %d files, add them all? " file-count))))
+       (message "Workspace file addition cancelled.")
+     (if only-open
+         (mapcar
+          (lambda (buffer)
+            (let ((file (buffer-file-name buffer)))
+              (when (and file (member (expand-file-name file) files))
+                (copilot-chat--add-buffer instance buffer))))
+          (buffer-list))
+       (mapcar (lambda (file) (copilot-chat-add-file file)) files)))))
 
 (defun copilot-chat-add-workspace-buffers ()
   "Add all open files matching an instance.
@@ -855,8 +974,9 @@ instance directory will be added."
   (interactive)
   (let ((instance (copilot-chat--current-instance)))
     (aio-with-async
-      (aio-await (copilot-chat--add-workspace instance t))
-      (copilot-chat-list-refresh instance))))
+     (aio-await
+      (copilot-chat--add-workspace instance t))
+     (copilot-chat-list-refresh instance))))
 
 (defun copilot-chat-add-workspace ()
   "Add all files in instance's directory.
@@ -867,8 +987,9 @@ displaying a file in the instance directory will be added."
   (interactive)
   (let ((instance (copilot-chat--current-instance)))
     (aio-with-async
-      (aio-await (copilot-chat--add-workspace instance nil))
-      (copilot-chat-list-refresh instance))))
+     (aio-await
+      (copilot-chat--add-workspace instance nil))
+     (copilot-chat-list-refresh instance))))
 
 (provide 'copilot-chat-command)
 ;;; copilot-chat-command.el ends here

--- a/copilot-chat-common.el
+++ b/copilot-chat-common.el
@@ -79,8 +79,3 @@
 
 (provide 'copilot-chat-common)
 ;;; copilot-chat-common.el ends here
-
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; package-lint-main-file: "copilot-chat.el"
-;; End:

--- a/copilot-chat-common.el
+++ b/copilot-chat-common.el
@@ -44,7 +44,8 @@
   :type 'boolean
   :group 'copilot-chat)
 
-(defcustom copilot-chat-github-token-file "~/.config/copilot-chat/github-token"
+(defcustom copilot-chat-github-token-file
+  "~/.config/copilot-chat/github-token"
   "The file where to find GitHub token."
   :type 'string
   :group 'copilot-chat)
@@ -58,11 +59,14 @@
 (defun copilot-chat--uuid ()
   "Generate a UUID."
   (format "%04x%04x-%04x-4%03x-%04x-%04x%04x%04x"
-          (random 65536) (random 65536)
+          (random 65536)
+          (random 65536)
           (random 65536)
           (logior (random 16384) 16384)
           (logior (random 4096) 32768)
-          (random 65536) (random 65536) (random 65536)))
+          (random 65536)
+          (random 65536)
+          (random 65536)))
 
 (defun copilot-chat--machine-id ()
   "Generate a machine ID."

--- a/copilot-chat-connection.el
+++ b/copilot-chat-connection.el
@@ -48,8 +48,3 @@
 
 (provide 'copilot-chat-connection)
 ;;; copilot-chat-connection.el ends here
-
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; package-lint-main-file: "copilot-chat.el"
-;; End:

--- a/copilot-chat-connection.el
+++ b/copilot-chat-connection.el
@@ -28,20 +28,19 @@
 
 (require 'cl-lib)
 
-(cl-defstruct (copilot-chat-connection
-               (:constructor copilot-chat-connection--make)
-               (:copier nil))
-  "Struct for Copilot connection information."
-  (ready nil :type boolean)
-  (github-token nil :type (or null string))
-  (token nil)
-  (sessionid nil :type (or null string))
-  (machineid nil :type (or null string))
-  (models nil :type list)
-  (last-models-fetch-time 0 :type number))
+(cl-defstruct
+ (copilot-chat-connection
+  (:constructor copilot-chat-connection--make) (:copier nil))
+ "Struct for Copilot connection information."
+ (ready nil :type boolean)
+ (github-token nil :type (or null string))
+ (token nil)
+ (sessionid nil :type (or null string))
+ (machineid nil :type (or null string))
+ (models nil :type list)
+ (last-models-fetch-time 0 :type number))
 
-(defvar copilot-chat--connection
-  (copilot-chat-connection--make)
+(defvar copilot-chat--connection (copilot-chat-connection--make)
   "Connection information for Copilot chat.")
 
 (cl-declaim (type copilot-chat-connection copilot-chat--connection))

--- a/copilot-chat-copilot.el
+++ b/copilot-chat-copilot.el
@@ -325,8 +325,3 @@ Argument DIRECTORY is the path to search for matching instance."
 
 (provide 'copilot-chat-copilot)
 ;;; copilot-chat-copilot.el ends here
-
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; package-lint-main-file: "copilot-chat.el"
-;; End:

--- a/copilot-chat-curl.el
+++ b/copilot-chat-curl.el
@@ -462,8 +462,3 @@ if the prompt is out of context."
 
 (provide 'copilot-chat-curl)
 ;;; copilot-chat-curl.el ends here
-
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; package-lint-main-file: "copilot-chat.el"
-;; End:

--- a/copilot-chat-debug.el
+++ b/copilot-chat-debug.el
@@ -46,11 +46,13 @@ No message is printed if `copilot-chat-debug' is nil."
       (signal 'wrong-type-argument (list 'symbolp category)))
     (unless (stringp format-string)
       (signal 'wrong-type-argument (list 'stringp format-string)))
-    (let ((formatted-msg (condition-case err
-                             (apply #'format format-string args)
-                           (error
-                            (message "Error formatting debug message: %S" err)
-                            (format "Error formatting message with args: %S" args)))))
+    (let ((formatted-msg
+           (condition-case err
+               (apply #'format format-string args)
+             (error
+              (message "Error formatting debug message: %S" err)
+              (format "Error formatting message with args: %S"
+                      args)))))
       (message "[copilot-chat:%s] %s" category formatted-msg))))
 
 (provide 'copilot-chat-debug)

--- a/copilot-chat-debug.el
+++ b/copilot-chat-debug.el
@@ -55,8 +55,3 @@ No message is printed if `copilot-chat-debug' is nil."
 
 (provide 'copilot-chat-debug)
 ;;; copilot-chat-debug.el ends here
-
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; package-lint-main-file: "copilot-chat.el"
-;; End:

--- a/copilot-chat-frontend.el
+++ b/copilot-chat-frontend.el
@@ -71,8 +71,3 @@ Argument INSTANCE is the copilot chat instance to get the buffer for."
 
 (provide 'copilot-chat-frontend)
 ;;; copilot-chat-frontend.el ends here
-
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; package-lint-main-file: "copilot-chat.el"
-;; End:

--- a/copilot-chat-frontend.el
+++ b/copilot-chat-frontend.el
@@ -30,42 +30,47 @@
 
 (defvar copilot-chat-frontend)
 
-(cl-defstruct copilot-chat-frontend
-  id
-  init-fn
-  clean-fn
-  format-fn
-  format-code-fn
-  format-buffer-fn
-  create-req-fn
-  send-to-buffer-fn
-  copy-fn
-  yank-fn
-  write-fn
-  get-buffer-fn
-  insert-prompt-fn
-  pop-prompt-fn
-  goto-input-fn
-  get-spinner-buffer-fn)
+(cl-defstruct
+ copilot-chat-frontend
+ id
+ init-fn
+ clean-fn
+ format-fn
+ format-code-fn
+ format-buffer-fn
+ create-req-fn
+ send-to-buffer-fn
+ copy-fn
+ yank-fn
+ write-fn
+ get-buffer-fn
+ insert-prompt-fn
+ pop-prompt-fn
+ goto-input-fn
+ get-spinner-buffer-fn)
 
 (defvar copilot-chat--frontend-list '()
   "Copilot-chat frontends and functions list.
 Each element must be a `copilot-chat-frontend' struct instance.
 Elements are added in the module that defines each front end.")
 
-(cl-declaim (type (list-of copilot-chat-frontend) copilot-chat--frontend-list))
+(cl-declaim
+ (type (list-of copilot-chat-frontend) copilot-chat--frontend-list))
 
 (defun copilot-chat--get-frontend ()
   "Get frontend from custom."
-  (cl-find copilot-chat-frontend copilot-chat--frontend-list
-           :key #'copilot-chat-frontend-id
-           :test #'eq))
+  (cl-find
+   copilot-chat-frontend
+   copilot-chat--frontend-list
+   :key #'copilot-chat-frontend-id
+   :test #'eq))
 
-(defun copilot-chat--get-buffer(instance)
+(defun copilot-chat--get-buffer (instance)
   "Get Copilot Chat buffer from the active frontend.
 Argument INSTANCE is the copilot chat instance to get the buffer for."
-  (let ((get-buffer-fn (copilot-chat-frontend-get-buffer-fn
-                        (copilot-chat--get-frontend))))
+  (let ((get-buffer-fn
+         (copilot-chat-frontend-get-buffer-fn
+          (copilot-chat--get-frontend))))
     (when get-buffer-fn
       (funcall get-buffer-fn instance))))
 

--- a/copilot-chat-git.el
+++ b/copilot-chat-git.el
@@ -34,17 +34,36 @@
   "The model to use specifically for commit message generation.
 When nil, falls back to `copilot-chat-default-model`.
 Set via `copilot-chat-set-commit-model'."
-  :type '(choice (const :tag "Use default model" nil)
-                 (string :tag "Specific model"))
+  :type
+  '(choice
+    (const :tag "Use default model" nil)
+    (string :tag "Specific model"))
   :group 'copilot-chat)
 
 (defcustom copilot-chat-ignored-commit-files
-  '("pnpm-lock.yaml" "package-lock.json" "yarn.lock" "poetry.lock"
-    "Cargo.lock" "go.sum" "composer.lock" "Gemfile.lock"
-    "requirements.txt" "*.pyc" "*.pyo" "*.pyd"
-    "*.so" "*.dylib" "*.dll" "*.exe"
-    "*.jar" "*.war" "*.ear"
-    "node_modules/" "vendor/" "dist/" "build/")
+  '("pnpm-lock.yaml"
+    "package-lock.json"
+    "yarn.lock"
+    "poetry.lock"
+    "Cargo.lock"
+    "go.sum"
+    "composer.lock"
+    "Gemfile.lock"
+    "requirements.txt"
+    "*.pyc"
+    "*.pyo"
+    "*.pyd"
+    "*.so"
+    "*.dylib"
+    "*.dll"
+    "*.exe"
+    "*.jar"
+    "*.war"
+    "*.ear"
+    "node_modules/"
+    "vendor/"
+    "dist/"
+    "build/")
   "List of file patterns to ignore when generating commit messages.
 These are typically large generated files like lock files or build artifacts
 that don't need to be included in commit message generation.
@@ -52,112 +71,136 @@ Supports glob patterns like `*.lock' or `node_modules/'."
   :type '(repeat string)
   :group 'copilot-chat)
 
-(aio-defun copilot-chat--exec (&rest command)
-  "Asynchronously execute command COMMAND and return its output string."
-  (let ((promise (aio-promise))
-        (buf (generate-new-buffer " *copilot-chat-shell-command*")))
-    (set-process-sentinel
-     (apply #'start-process "copilot-chat-shell-command" buf command)
-     (lambda (proc _signal)
-       (when (memq (process-status proc) '(exit signal))
-         (with-current-buffer buf
-           (let ((data (buffer-string)))
-             (aio-resolve promise
-                          (lambda ()
-                            (if (> (length data) 0)
-                                (substring data 0 -1) "")))))
-         (kill-buffer buf))))
-    (aio-await promise)))
+(aio-defun
+ copilot-chat--exec
+ (&rest command)
+ "Asynchronously execute command COMMAND and return its output string."
+ (let ((promise (aio-promise))
+       (buf (generate-new-buffer " *copilot-chat-shell-command*")))
+   (set-process-sentinel
+    (apply #'start-process "copilot-chat-shell-command" buf command)
+    (lambda (proc _signal)
+      (when (memq (process-status proc) '(exit signal))
+        (with-current-buffer buf
+          (let ((data (buffer-string)))
+            (aio-resolve
+             promise
+             (lambda ()
+               (if (> (length data) 0)
+                   (substring data 0 -1)
+                 "")))))
+        (kill-buffer buf))))
+   (aio-await promise)))
 
-(aio-defun copilot-chat--git-top-level ()
-  "Get top folder of current git repo."
-  (when (executable-find "git")
-    (let* ((git-dir (aio-await (copilot-chat--exec "git" "rev-parse" "--absolute-git-dir")))
-           (default-directory git-dir)
-           cdup)
-      (cond
-       ((file-exists-p "gitdir")      ; worktree case
-        (with-temp-buffer
-          (insert-file-contents "gitdir")
-          (file-name-directory (buffer-string))))
-       ((and (setq cdup (aio-await (copilot-chat--exec "git" "rev-parse" "--show-cdup")))
-             (not (string-empty-p cdup))) ; submodule case
-        cdup)
-       (t (file-name-directory git-dir))))))
+(aio-defun
+ copilot-chat--git-top-level () "Get top folder of current git repo."
+ (when (executable-find "git")
+   (let* ((git-dir
+           (aio-await
+            (copilot-chat--exec
+             "git" "rev-parse" "--absolute-git-dir")))
+          (default-directory git-dir)
+          cdup)
+     (cond
+      ((file-exists-p "gitdir") ; worktree case
+       (with-temp-buffer
+         (insert-file-contents "gitdir")
+         (file-name-directory (buffer-string))))
+      ((and (setq cdup
+                  (aio-await
+                   (copilot-chat--exec
+                    "git" "rev-parse" "--show-cdup")))
+            (not (string-empty-p cdup))) ; submodule case
+       cdup)
+      (t
+       (file-name-directory git-dir))))))
 
 
-(aio-defun copilot-chat--git-ls-files (repo-root)
-  "Return a list of git managed files in REPO-ROOT.
+(aio-defun
+ copilot-chat--git-ls-files (repo-root)
+ "Return a list of git managed files in REPO-ROOT.
 Uses `git ls-files` to retrieve files that are tracked or not ignored by
 Git.  REPO-ROOT must be git top directory."
-  (let* ((default-directory repo-root)
-         (ls-output
-          (aio-await (copilot-chat--exec
-                      "git" "--no-pager" "ls-files" "--full-name")))
-         (all-files (split-string ls-output "\n" t)))
-    (mapcar
-     (lambda (file)
-       (expand-file-name file repo-root))
-     all-files)))
+ (let* ((default-directory repo-root)
+        (ls-output
+         (aio-await
+          (copilot-chat--exec
+           "git" "--no-pager" "ls-files" "--full-name")))
+        (all-files (split-string ls-output "\n" t)))
+   (mapcar
+    (lambda (file) (expand-file-name file repo-root)) all-files)))
 
-(aio-defun copilot-chat--get-diff ()
-  "Get the diff of staged change in the current git repository.
+(aio-defun
+ copilot-chat--get-diff ()
+ "Get the diff of staged change in the current git repository.
 Returns a string containing the diff, excluding files specified in
 `copilot-chat-ignored-commit-files'.  Returns nil if not in a git
 repository or if there are no staged changes.
 
 +The diff is generated using git and excludes files matching patterns in
 +`copilot-chat-ignored-commit-files', such as lock files and build artifacts."
-  (let* ((default-directory (or (aio-await (copilot-chat--git-top-level))
-                                (user-error "Not inside a Git repository")))
-         ;; First get list of staged files
-         (staged-files (split-string
-                        (aio-await
-                         (copilot-chat--exec "git"
-                                             "--no-pager"
-                                             "diff"
-                                             "--cached"
-                                             "--name-only"))
-                        "\n" t))
-         (files-to-include
-          (cl-remove-if
-           (lambda (file)
-             (cl-some (lambda (pattern)
-                        (or (string-match-p (wildcard-to-regexp pattern) file)
-                            (and (string-suffix-p "/" pattern)
-                                 (string-prefix-p pattern file))))
-                      copilot-chat-ignored-commit-files))
-           staged-files)))
-    ;; Then get diff only for non-ignored files
-    (when files-to-include
-      (aio-await
-       (apply #'copilot-chat--exec
-              "git" "--no-pager" "diff" "--cached" "--" files-to-include)))))
+ (let* ((default-directory
+         (or (aio-await (copilot-chat--git-top-level))
+             (user-error "Not inside a Git repository")))
+        ;; First get list of staged files
+        (staged-files
+         (split-string (aio-await
+                        (copilot-chat--exec
+                         "git"
+                         "--no-pager"
+                         "diff"
+                         "--cached"
+                         "--name-only"))
+                       "\n" t))
+        (files-to-include
+         (cl-remove-if
+          (lambda (file)
+            (cl-some
+             (lambda (pattern)
+               (or (string-match-p (wildcard-to-regexp pattern) file)
+                   (and (string-suffix-p "/" pattern)
+                        (string-prefix-p pattern file))))
+             copilot-chat-ignored-commit-files))
+          staged-files)))
+   ;; Then get diff only for non-ignored files
+   (when files-to-include
+     (aio-await
+      (apply #'copilot-chat--exec
+             "git"
+             "--no-pager"
+             "diff"
+             "--cached"
+             "--"
+             files-to-include)))))
 
 (defun copilot-chat--create-commit-instance ()
   "Create a temporary, lightweight instance for commit message generation.
 This instance is specifically designed for generating commit messages
 without creating a chat buffer or setting up a full chat environment."
-  (let ((current-dir (file-name-directory (or (buffer-file-name) default-directory))))
-    (let ((instance (copilot-chat--make
-                     :directory current-dir
-                     :model (or copilot-chat-commit-model copilot-chat-default-model)
-                     :type 'commit
-                     :chat-buffer nil
-                     :first-word-answer t
-                     :history nil
-                     :buffers nil
-                     :prompt-history nil
-                     :prompt-history-position nil
-                     :yank-index 1
-                     :last-yank-start nil
-                     :last-yank-end nil
-                     :spinner-timer nil
-                     :spinner-index 0
-                     :spinner-status nil
-                     :curl-answer nil
-                     :curl-file nil
-                     :curl-current-data nil)))
+  (let ((current-dir
+         (file-name-directory
+          (or (buffer-file-name) default-directory))))
+    (let ((instance
+           (copilot-chat--make
+            :directory current-dir
+            :model
+            (or copilot-chat-commit-model copilot-chat-default-model)
+            :type 'commit
+            :chat-buffer nil
+            :first-word-answer t
+            :history nil
+            :buffers nil
+            :prompt-history nil
+            :prompt-history-position nil
+            :yank-index 1
+            :last-yank-start nil
+            :last-yank-end nil
+            :spinner-timer nil
+            :spinner-index 0
+            :spinner-status nil
+            :curl-answer nil
+            :curl-file nil
+            :curl-current-data nil)))
       ;; Store instance in our instances list to prevent GC issues with timers
       (push instance copilot-chat--instances)
       instance)))
@@ -171,7 +214,13 @@ without creating a chat buffer or setting up a full chat environment."
         (setq comments (concat comments (match-string 0) "\n")))
       comments)))
 
-(defun copilot-chat--commit-callback (instance current-buf start-pos accumulated-content template-comments wait-prompt)
+(defun copilot-chat--commit-callback
+    (instance
+     current-buf
+     start-pos
+     accumulated-content
+     template-comments
+     wait-prompt)
   "Callback function for handling commit message generation stream.
 INSTANCE is the copilot chat instance receiving data.
 CURRENT-BUF is the buffer where commit message will be inserted.
@@ -192,28 +241,39 @@ WAIT-PROMPT is the temporary waiting message shown during generation."
               (with-current-buffer current-buf
                 (goto-char start-pos)
                 (when (looking-at wait-prompt)
-                  (delete-region start-pos (+ start-pos (length wait-prompt))))
+                  (delete-region
+                   start-pos (+ start-pos (length wait-prompt))))
                 ;; Restore the git commit template comments and insert generated message
                 (goto-char (point-max))
                 (delete-region (point-min) (point-max))
                 (insert accumulated-content "\n\n" template-comments))
               (message "Commit message generation completed.")
-              (copilot-chat--debug 'commit "Generation completed successfully")
+              (copilot-chat--debug
+               'commit "Generation completed successfully")
 
               ;; Remove the temporary instance from instances list to avoid memory leaks
-              (setq copilot-chat--instances (delq instance copilot-chat--instances)))
+              (setq copilot-chat--instances
+                    (delq instance copilot-chat--instances)))
 
           (progn
             (when (string= accumulated-content "")
               (goto-char start-pos)
               (when (looking-at wait-prompt)
-                (delete-region start-pos (+ start-pos (length wait-prompt)))))
+                (delete-region
+                 start-pos (+ start-pos (length wait-prompt)))))
 
             (goto-char start-pos)
-            (delete-region start-pos (min (+ start-pos (length accumulated-content)) (point-max)))
-            (setq accumulated-content (concat accumulated-content content))
+            (delete-region
+             start-pos
+             (min (+ start-pos (length accumulated-content))
+                  (point-max)))
+            (setq accumulated-content
+                  (concat accumulated-content content))
             (insert accumulated-content)
-            (copilot-chat--debug 'commit "Received chunk: %d chars" (length content))))))))
+            (copilot-chat--debug
+             'commit
+             "Received chunk: %d chars"
+             (length content))))))))
 
 ;;;###autoload (autoload 'copilot-chat-insert-commit-message-when-ready "copilot-chat" nil t)
 (defun copilot-chat-insert-commit-message-when-ready ()
@@ -222,44 +282,58 @@ Uses the current staged changes in git to generate an appropriate commit
 message.  Requires the repository to have staged changes ready for commit."
   (interactive)
   (aio-with-async
-    (let* ((instance (copilot-chat--create-commit-instance))
-           (current-buf (current-buffer))
-           (start-pos (point))
-           (diff (aio-await (copilot-chat--get-diff)))
-           (template-comments (copilot-chat--get-git-commit-template-comments))
-           (wait-prompt (format "# [copilot:%s] Generating commit message..." (copilot-chat-model instance)))
-           (accumulated-content ""))
+   (let* ((instance (copilot-chat--create-commit-instance))
+          (current-buf (current-buffer))
+          (start-pos (point))
+          (diff (aio-await (copilot-chat--get-diff)))
+          (template-comments
+           (copilot-chat--get-git-commit-template-comments))
+          (wait-prompt
+           (format "# [copilot:%s] Generating commit message..."
+                   (copilot-chat-model instance)))
+          (accumulated-content ""))
 
-      (copilot-chat--debug 'commit "Starting direct commit message generation")
-      (copilot-chat--debug 'commit "Diff size: %d bytes, Model: %s"
-                           (length diff) (copilot-chat-model instance))
+     (copilot-chat--debug
+      'commit "Starting direct commit message generation")
+     (copilot-chat--debug
+      'commit
+      "Diff size: %d bytes, Model: %s"
+      (length diff)
+      (copilot-chat-model instance))
 
-      (cond
-       ((string-empty-p diff)
-        (copilot-chat--debug 'commit "No changes found in staging area")
-        (setq copilot-chat--instances (delq instance copilot-chat--instances))
-        (user-error "No staged changes found.  Please stage some changes first"))
+     (cond
+      ((string-empty-p diff)
+       (copilot-chat--debug
+        'commit "No changes found in staging area")
+       (setq copilot-chat--instances
+             (delq instance copilot-chat--instances))
+       (user-error
+        "No staged changes found.  Please stage some changes first"))
 
-       (t
-        (message "Generating commit message...")
-        (insert wait-prompt "\n\n")
-        (goto-char start-pos)
+      (t
+       (message "Generating commit message...")
+       (insert wait-prompt "\n\n")
+       (goto-char start-pos)
 
-        (condition-case err
-            (copilot-chat--ask
+       (condition-case err
+           (copilot-chat--ask
+            instance (concat copilot-chat-commit-prompt diff)
+            (copilot-chat--commit-callback
              instance
-             (concat copilot-chat-commit-prompt diff)
-             (copilot-chat--commit-callback
-              instance current-buf start-pos accumulated-content
-              template-comments wait-prompt)
-             t) ; out-of-context = t
-          (error
-           ;; Ensure the instance is cleaned up if an error occurs
-           (when (copilot-chat-spinner-timer instance)
-             (cancel-timer (copilot-chat-spinner-timer instance))
-             (setf (copilot-chat-spinner-timer instance) nil))
-           (setq copilot-chat--instances (delq instance copilot-chat--instances))
-           (signal (car err) (cdr err)))))))))
+             current-buf
+             start-pos
+             accumulated-content
+             template-comments
+             wait-prompt)
+            t) ; out-of-context = t
+         (error
+          ;; Ensure the instance is cleaned up if an error occurs
+          (when (copilot-chat-spinner-timer instance)
+            (cancel-timer (copilot-chat-spinner-timer instance))
+            (setf (copilot-chat-spinner-timer instance) nil))
+          (setq copilot-chat--instances
+                (delq instance copilot-chat--instances))
+          (signal (car err) (cdr err)))))))))
 
 ;;;###autoload (autoload 'copilot-chat-insert-commit-message "copilot-chat" nil t)
 (defun copilot-chat-insert-commit-message ()
@@ -272,31 +346,36 @@ This function is expected to be safe to open via magit when added to
   ;;FIXME: I really don't want to do anything delayed by time,
   ;; but I had to in order to make it work anyway.
   ;; In fact, we would like to get rid of this kind of messy control.
-  (run-with-timer 1 nil #'copilot-chat-insert-commit-message-when-ready))
+  (run-with-timer
+   1 nil #'copilot-chat-insert-commit-message-when-ready))
 
 ;;;###autoload (autoload 'copilot-chat-set-commit-model "copilot-chat" nil t)
 (defun copilot-chat-set-commit-model (model)
   "Set the model to use specifically for commit message generation to MODEL.
 When called interactively, prompts for available models from the API."
   (interactive
-   (let* ((choices (copilot-chat--get-model-choices-with-wait))
-          (max-id-width
-           (apply #'max
-                  (mapcar (lambda (choics)
-                            (length (cdr choics))) choices)))
-          ;; Create completion list with ID as prefix for unique identification
-          (completion-choices
-           (mapcar (lambda (choice)
-                     (let ((name (car choice))
-                           (id (cdr choice)))
-                       (cons (format (format "[%%-%ds] %%s" max-id-width)
-                                     id name)
-                             id)))
-                   choices))
-          (choice
-           (completing-read "Select commit message model: "
-                            (mapcar 'car completion-choices)
-                            nil t)))
+   (let*
+       ((choices (copilot-chat--get-model-choices-with-wait))
+        (max-id-width
+         (apply #'max
+                (mapcar
+                 (lambda (choics) (length (cdr choics))) choices)))
+        ;; Create completion list with ID as prefix for unique identification
+        (completion-choices
+         (mapcar
+          (lambda (choice)
+            (let ((name (car choice))
+                  (id (cdr choice)))
+              (cons
+               (format (format "[%%-%ds] %%s" max-id-width)
+                       id name)
+               id)))
+          choices))
+        (choice
+         (completing-read "Select commit message model: "
+                          (mapcar 'car completion-choices)
+                          nil
+                          t)))
      ;; Extract model ID from the selected choice
      (let ((model-value (cdr (assoc choice completion-choices))))
        (when copilot-chat-debug

--- a/copilot-chat-git.el
+++ b/copilot-chat-git.el
@@ -309,8 +309,3 @@ When called interactively, prompts for available models from the API."
 
 (provide 'copilot-chat-git)
 ;;; copilot-chat-git.el ends here
-
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; package-lint-main-file: "copilot-chat.el"
-;; End:

--- a/copilot-chat-instance.el
+++ b/copilot-chat-instance.el
@@ -87,8 +87,3 @@ Use `copilot-chat-set-model' to interactively select a model."
 
 (provide 'copilot-chat-instance)
 ;;; copilot-chat-instance.el ends here
-
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; package-lint-main-file: "copilot-chat.el"
-;; End:

--- a/copilot-chat-instance.el
+++ b/copilot-chat-instance.el
@@ -36,31 +36,30 @@ Use `copilot-chat-set-model' to interactively select a model."
   :type 'string
   :group 'copilot-chat)
 
-(cl-defstruct (copilot-chat
-               (:constructor copilot-chat--make)
-               (:copier nil))
-  "Struct for Copilot chat state."
-  (directory nil :type (or null string))
-  (model copilot-chat-default-model :type string)
-  (type nil :type (or null symbol))
-  (chat-buffer nil :type (or null buffer))
-  (first-word-answer t :type boolean)
-  (history nil :type list)
-  (buffers nil :type list)
-  (prompt-history nil :type list)
-  (prompt-history-position nil :type (or null int))
-  (yank-index 1 :type int)
-  (last-yank-start nil :type (or null point))
-  (last-yank-end nil :type (or null point))
-  (spinner-timer nil :type timer)
-  (spinner-index 0 :type int)
-  (spinner-status nil :type (or null string))
-  (curl-answer nil :type (or null string))
-  (curl-file nil :type (or null file))
-  (curl-current-data nil :type (or null string))
-  (shell-maker-tmp-buf nil :type buffer)
-  (shell-maker-answer-point nil :type point)
-  (shell-cb-fn nil :type function))
+(cl-defstruct
+ (copilot-chat (:constructor copilot-chat--make) (:copier nil))
+ "Struct for Copilot chat state."
+ (directory nil :type (or null string))
+ (model copilot-chat-default-model :type string)
+ (type nil :type (or null symbol))
+ (chat-buffer nil :type (or null buffer))
+ (first-word-answer t :type boolean)
+ (history nil :type list)
+ (buffers nil :type list)
+ (prompt-history nil :type list)
+ (prompt-history-position nil :type (or null int))
+ (yank-index 1 :type int)
+ (last-yank-start nil :type (or null point))
+ (last-yank-end nil :type (or null point))
+ (spinner-timer nil :type timer)
+ (spinner-index 0 :type int)
+ (spinner-status nil :type (or null string))
+ (curl-answer nil :type (or null string))
+ (curl-file nil :type (or null file))
+ (curl-current-data nil :type (or null string))
+ (shell-maker-tmp-buf nil :type buffer)
+ (shell-maker-answer-point nil :type point)
+ (shell-cb-fn nil :type function))
 
 (defvar copilot-chat--instances (list)
   "Global instance of Copilot chat.")
@@ -76,13 +75,16 @@ Use `copilot-chat-set-model' to interactively select a model."
 
 (defun copilot-chat--get-list-buffer-create (instance)
   "Get or create the Copilot chat list buffer for INSTANCE."
-  (let ((list-buffer (get-buffer-create
-                      (concat copilot-chat-list-buffer
-                              "-"
-                              (copilot-chat-directory instance)
-                              "*"))))
+  (let ((list-buffer
+         (get-buffer-create
+          (concat
+           copilot-chat-list-buffer
+           "-"
+           (copilot-chat-directory instance)
+           "*"))))
     (with-current-buffer list-buffer
-      (setq-local default-directory (copilot-chat-directory instance)))
+      (setq-local default-directory
+                  (copilot-chat-directory instance)))
     list-buffer))
 
 (provide 'copilot-chat-instance)

--- a/copilot-chat-markdown.el
+++ b/copilot-chat-markdown.el
@@ -41,30 +41,36 @@
   "The delimiter used to identify copilot chat input.")
 
 ;;; Polymode
-(define-derived-mode copilot-chat-markdown-prompt-mode
-  markdown-mode
-  "Copilot Chat markdown Prompt"
-  "Major mode for the Copilot Chat Prompt region."
-  (setq major-mode 'copilot-chat-markdown-prompt-mode
-        mode-name "Copilot Chat markdown prompt")
-  (copilot-chat-prompt-mode))
+(define-derived-mode
+ copilot-chat-markdown-prompt-mode
+ markdown-mode
+ "Copilot Chat markdown Prompt"
+ "Major mode for the Copilot Chat Prompt region."
+ (setq
+  major-mode 'copilot-chat-markdown-prompt-mode
+  mode-name "Copilot Chat markdown prompt")
+ (copilot-chat-prompt-mode))
 
-(define-hostmode poly-copilot-markdown-hostmode
-  :mode 'copilot-chat-markdown-prompt-mode)
+(define-hostmode
+ poly-copilot-markdown-hostmode
+ :mode 'copilot-chat-markdown-prompt-mode)
 
-(define-innermode poly-copilot-markdown-innermode
-  :mode 'markdown-view-mode
-  :head-matcher "\\`"  ; Match beginning of buffer
-  :tail-matcher (concat copilot-chat--markdown-delimiter "\n")
-  :head-mode 'inner
-  :tail-mode 'host)
+(define-innermode
+ poly-copilot-markdown-innermode
+ :mode 'markdown-view-mode
+ :head-matcher "\\`" ; Match beginning of buffer
+ :tail-matcher (concat copilot-chat--markdown-delimiter "\n")
+ :head-mode 'inner
+ :tail-mode 'host)
 
-(declare-function copilot-chat-markdown-poly-mode "copilot-chat-markdown"
+(declare-function copilot-chat-markdown-poly-mode
+                  "copilot-chat-markdown"
                   "Polymode for Copilot Chat Markdown.")
 
-(define-polymode copilot-chat-markdown-poly-mode
-  :hostmode 'poly-copilot-markdown-hostmode
-  :innermodes '(poly-copilot-markdown-innermode))
+(define-polymode
+ copilot-chat-markdown-poly-mode
+ :hostmode 'poly-copilot-markdown-hostmode
+ :innermodes '(poly-copilot-markdown-innermode))
 
 
 ;;; Functions
@@ -76,15 +82,20 @@ Argument TYPE is the type of data to format: `answer` or `prompt`."
     (if (eq type 'prompt)
         (progn
           (setf (copilot-chat-first-word-answer instance) t)
-          (setq data (concat "\n# "
-                             (format-time-string "*[%T]* You\n")
-                             (format "%s\n" content))))
+          (setq data
+                (concat
+                 "\n# "
+                 (format-time-string "*[%T]* You\n")
+                 (format "%s\n" content))))
       (when (copilot-chat-first-word-answer instance)
         (setf (copilot-chat-first-word-answer instance) nil)
-        (setq data (concat "\n## "
-                           (concat (format-time-string "*[%T]* ")
-                                   (format "Copilot(%s):\n"
-                                           (copilot-chat-model instance))))))
+        (setq data
+              (concat
+               "\n## "
+               (concat
+                (format-time-string "*[%T]* ")
+                (format "Copilot(%s):\n"
+                        (copilot-chat-model instance))))))
       (setq data (concat data content)))
     data))
 
@@ -96,7 +107,7 @@ Argument LANGUAGE is the language of the code."
       (format "\n```%s\n%s\n```\n" language code)
     code))
 
-(defun copilot-chat--markdown-format-buffer(buffer instance)
+(defun copilot-chat--markdown-format-buffer (buffer instance)
   "Format the content of a buffer into a Markdown-compatible string.
 This function extracts the content of the specified BUFFER, determines
 its file name, relative path, and programming language, and formats the
@@ -104,15 +115,18 @@ content as a Markdown code block.
 INSTANCE is `copilot-chat' instance, used to retrieve relative file path."
   (with-current-buffer buffer
     (let* ((file-name (buffer-file-name))
-           (relative-path (if file-name
-                              (file-relative-name file-name (copilot-chat-directory instance))
-                            (buffer-name)))
-           (content (copilot-chat--markdown-format-code
-                     (buffer-substring-no-properties (point-min) (point-max))
-                     relative-path)))
+           (relative-path
+            (if file-name
+                (file-relative-name file-name
+                                    (copilot-chat-directory instance))
+              (buffer-name)))
+           (content
+            (copilot-chat--markdown-format-code
+             (buffer-substring-no-properties (point-min) (point-max))
+             relative-path)))
       content)))
 
-(defun copilot-chat--markdown-clean()
+(defun copilot-chat--markdown-clean ()
   "Clean the copilot chat markdown frontend.")
 
 (defun copilot-chat--get-markdown-block-content-at-point ()
@@ -122,27 +136,33 @@ INSTANCE is `copilot-chat' instance, used to retrieve relative file path."
     (when (and (listp face)
                (or (memq 'markdown-pre-face face)
                    (memq 'markdown-code-face face)))
-      (let* ((begin-block (previous-single-property-change (point) 'face))
+      (let* ((begin-block
+              (previous-single-property-change (point) 'face))
              (end-block (next-single-property-change (point) 'face))
-             (content (when (and begin-block end-block)
-                        (buffer-substring-no-properties begin-block end-block)))
+             (content
+              (when (and begin-block end-block)
+                (buffer-substring-no-properties
+                 begin-block end-block)))
              ;; Try to get language from previous text properties
-             (lang-props (text-properties-at (max (- begin-block 1) (point-min))))
+             (lang-props
+              (text-properties-at
+               (max (- begin-block 1) (point-min))))
              (lang (plist-get lang-props 'markdown-language)))
         (when content
-          (list :content content
-                :language lang))))))
+          (list :content content :language lang))))))
 
-(defun copilot-chat--markdown-send-to-buffer()
+(defun copilot-chat--markdown-send-to-buffer ()
   "Send the code block at point to buffer.
 Replace selection if any."
-  (let ((buffer (completing-read "Choose buffer: "
-                                 (mapcar #'buffer-name (buffer-list))
-                                 nil  ; PREDICATE
-                                 t    ; REQUIRE-MATCH
-                                 nil  ; INITIAL-INPUT
-                                 'buffer-name-history
-                                 (buffer-name (current-buffer))))
+  (let ((buffer
+         (completing-read
+          "Choose buffer: "
+          (mapcar #'buffer-name (buffer-list))
+          nil ; PREDICATE
+          t ; REQUIRE-MATCH
+          nil ; INITIAL-INPUT
+          'buffer-name-history
+          (buffer-name (current-buffer))))
         (content (copilot-chat--get-markdown-block-content-at-point)))
     (when content
       (with-current-buffer buffer
@@ -188,12 +208,14 @@ The input is created if not found."
   "Create `copilot-chat' buffers for INSTANCE."
   (unless (buffer-live-p (copilot-chat-chat-buffer instance))
     (setf (copilot-chat-chat-buffer instance)
-          (get-buffer-create (copilot-chat--get-buffer-name
-                              (copilot-chat-directory instance))))
+          (get-buffer-create
+           (copilot-chat--get-buffer-name
+            (copilot-chat-directory instance))))
     (with-current-buffer (copilot-chat-chat-buffer instance)
       (copilot-chat-markdown-poly-mode)
       (copilot-chat--markdown-goto-input)
-      (setq-local default-directory (copilot-chat-directory instance))))
+      (setq-local default-directory
+                  (copilot-chat-directory instance))))
   (copilot-chat-chat-buffer instance))
 
 
@@ -218,7 +240,8 @@ The input is created if not found."
 INSTANCE is `copilot-chat' instance to use."
   (with-current-buffer (copilot-chat--markdown-get-buffer instance)
     (copilot-chat--markdown-goto-input)
-    (let ((prompt (buffer-substring-no-properties (point) (point-max))))
+    (let ((prompt
+           (buffer-substring-no-properties (point) (point-max))))
       (delete-region (point) (point-max))
       prompt)))
 

--- a/copilot-chat-markdown.el
+++ b/copilot-chat-markdown.el
@@ -254,6 +254,4 @@ INSTANCE is `copilot-chat' instance to use."
 
 ;; Local Variables:
 ;; byte-compile-warnings: (not obsolete)
-;; indent-tabs-mode: nil
-;; package-lint-main-file: "copilot-chat.el"
 ;; End:

--- a/copilot-chat-model.el
+++ b/copilot-chat-model.el
@@ -95,8 +95,3 @@ is not `true' are not included in the model selection by default."
 
 (provide 'copilot-chat-model)
 ;;; copilot-chat-model.el ends here
-
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; package-lint-main-file: "copilot-chat.el"
-;; End:

--- a/copilot-chat-model.el
+++ b/copilot-chat-model.el
@@ -31,7 +31,8 @@
 
 (require 'copilot-chat-debug)
 
-(defcustom copilot-chat-models-cache-file "~/.cache/copilot-chat/models.json"
+(defcustom copilot-chat-models-cache-file
+  "~/.cache/copilot-chat/models.json"
   "File to cache fetched models."
   :type 'string
   :group 'copilot-chat)
@@ -59,8 +60,9 @@ is not `true' are not included in the model selection by default."
 (defun copilot-chat--save-models-to-cache (models)
   "Save MODELS to disk cache."
   (when models
-    (let ((cache-data `((timestamp . ,(round (float-time)))
-                        (models . ,(vconcat models)))))
+    (let ((cache-data
+           `((timestamp . ,(round (float-time)))
+             (models . ,(vconcat models)))))
       (with-temp-file copilot-chat-models-cache-file
         (insert (json-serialize cache-data)))
       (when copilot-chat-debug
@@ -81,12 +83,14 @@ is not `true' are not included in the model selection by default."
             (if (< age copilot-chat-models-cache-ttl)
                 (let ((models (alist-get 'models cache-data)))
                   (when copilot-chat-debug
-                    (message "Loaded %d models from cache (age: %d seconds)"
-                             (length models) age))
+                    (message
+                     "Loaded %d models from cache (age: %d seconds)"
+                     (length models) age))
                   models)
               (when copilot-chat-debug
-                (message "Cache expired (age: %d seconds, ttl: %d seconds)"
-                         age copilot-chat-models-cache-ttl))
+                (message
+                 "Cache expired (age: %d seconds, ttl: %d seconds)"
+                 age copilot-chat-models-cache-ttl))
               nil))
         (error
          (when copilot-chat-debug

--- a/copilot-chat-org.el
+++ b/copilot-chat-org.el
@@ -333,6 +333,4 @@ INSTANCE is `copilot-chat' instance to use."
 
 ;; Local Variables:
 ;; byte-compile-warnings: (not obsolete)
-;; indent-tabs-mode: nil
-;; package-lint-main-file: "copilot-chat.el"
 ;; End:

--- a/copilot-chat-org.el
+++ b/copilot-chat-org.el
@@ -35,40 +35,43 @@
 (require 'copilot-chat-prompts)
 
 ;;; Constants
-(defconst copilot-chat--org-answer-tag
-  "copilot"
+(defconst copilot-chat--org-answer-tag "copilot"
   "The tag used to identify copilot chat answers.")
-(defconst copilot-chat--org-delimiter
-  "* ╭──── Chat Input ────╮"
+(defconst copilot-chat--org-delimiter "* ╭──── Chat Input ────╮"
   "The delimiter used to identify copilot chat input.")
 
 ;;; Polymode
-(define-derived-mode copilot-chat-org-prompt-mode org-mode "Copilot Chat org Prompt"
-  "Major mode for the Copilot Chat Prompt region."
-  (setq major-mode 'copilot-chat-org-prompt-mode
-        mode-name "Copilot Chat org prompt")
-  (copilot-chat-prompt-mode))
+(define-derived-mode
+ copilot-chat-org-prompt-mode
+ org-mode
+ "Copilot Chat org Prompt"
+ "Major mode for the Copilot Chat Prompt region."
+ (setq
+  major-mode 'copilot-chat-org-prompt-mode
+  mode-name "Copilot Chat org prompt")
+ (copilot-chat-prompt-mode))
 
-(define-hostmode poly-copilot-org-hostmode
-  :mode 'org-mode)
+(define-hostmode poly-copilot-org-hostmode :mode 'org-mode)
 
-(define-innermode poly-copilot-org-prompt-innermode
-  :mode 'copilot-chat-org-prompt-mode
-  :head-matcher (concat copilot-chat--org-delimiter "\n")
-  :tail-matcher "\\'"
-  :head-mode 'host
-  :tail-mode 'host)
+(define-innermode
+ poly-copilot-org-prompt-innermode
+ :mode 'copilot-chat-org-prompt-mode
+ :head-matcher (concat copilot-chat--org-delimiter "\n")
+ :tail-matcher "\\'"
+ :head-mode 'host
+ :tail-mode 'host)
 
 (declare-function copilot-chat-org-poly-mode "copilot-chat-org"
                   "Polymode for Copilot Chat Org.")
 
-(define-polymode copilot-chat-org-poly-mode
-  :hostmode 'poly-copilot-org-hostmode
-  :innermodes '(poly-copilot-org-prompt-innermode))
+(define-polymode
+ copilot-chat-org-poly-mode
+ :hostmode 'poly-copilot-org-hostmode
+ :innermodes '(poly-copilot-org-prompt-innermode))
 
 
 ;;; Functions
-(defun copilot-chat--org-format-data(instance content type)
+(defun copilot-chat--org-format-data (instance content type)
   "Format data for org frontend.
 INSTANCE is `copilot-chat' instance to use.
 Argument CONTENT is the data to format.
@@ -77,20 +80,23 @@ Argument TYPE is the type of the data (prompt or answer)."
     (if (eq type 'prompt)
         (progn
           (setf (copilot-chat-first-word-answer instance) t)
-          (setq data (concat "\n* "
-                             (format-time-string "*[%T]* You\n")
-                             (format "%s\n" content))))
+          (setq data
+                (concat
+                 "\n* "
+                 (format-time-string "*[%T]* You\n")
+                 (format "%s\n" content))))
       (when (copilot-chat-first-word-answer instance)
         (setf (copilot-chat-first-word-answer instance) nil)
-        (setq data (concat "\n** "
-                           (format-time-string "*[%T]* ")
-                           (format "Copilot(%s)                 :%s:\n"
-                                   (copilot-chat-model instance)
-                                   copilot-chat--org-answer-tag))))
+        (setq data
+              (concat
+               "\n** " (format-time-string "*[%T]* ")
+               (format "Copilot(%s)                 :%s:\n"
+                       (copilot-chat-model instance)
+                       copilot-chat--org-answer-tag))))
       (setq data (concat data content)))
     data))
 
-(defun copilot-chat--org-format-code(code language)
+(defun copilot-chat--org-format-code (code language)
   "Format code for org frontend.
 Argument CODE is the code to format.
 Argument LANGUAGE is the language of the code."
@@ -98,7 +104,7 @@ Argument LANGUAGE is the language of the code."
       (format "\n#+BEGIN_SRC %s\n%s\n#+END_SRC\n" language code)
     code))
 
-(defun copilot-chat--org-format-buffer(buffer instance)
+(defun copilot-chat--org-format-buffer (buffer instance)
   "Format the content of a buffer into an org compatible string.
 This function extracts the content of the specified BUFFER, determines
 its file name, relative path, and programming language, and formats the
@@ -106,22 +112,23 @@ content as a org mode code block.
 INSTANCE is `copilot-chat' instance, used to retrieve relative file path."
   (with-current-buffer buffer
     (let* ((file-name (buffer-file-name))
-           (relative-path (if file-name
-                              (file-relative-name file-name
-                                                  (copilot-chat-directory instance))
-                            (buffer-name)))
-           (language (if (derived-mode-p 'prog-mode)
-                         (replace-regexp-in-string "\\(?:-ts\\)?-mode\\'" ""
-                                                   (symbol-name major-mode))
-                       "text"))
-           (content (copilot-chat--org-format-code
-                     (buffer-substring-no-properties (point-min) (point-max))
-                     language)))
+           (relative-path
+            (if file-name
+                (file-relative-name file-name
+                                    (copilot-chat-directory instance))
+              (buffer-name)))
+           (language
+            (if (derived-mode-p 'prog-mode)
+                (replace-regexp-in-string
+                 "\\(?:-ts\\)?-mode\\'" "" (symbol-name major-mode))
+              "text"))
+           (content
+            (copilot-chat--org-format-code
+             (buffer-substring-no-properties (point-min) (point-max))
+             language)))
 
       ;; Return the formatted string with metadata
-      (format "* FILE %s\n%s"
-              relative-path
-              content))))
+      (format "* FILE %s\n%s" relative-path content))))
 
 (defun copilot-chat--org-create-req (prompt no-context)
   "Create a request with `org-mode' syntax reminder.
@@ -129,7 +136,8 @@ PROMPT is the input text.  If NO-CONTEXT is t, do nothing because we are
 asking for a commit message."
   (if no-context
       prompt
-    (format "%s\n\nUse only Emacs org-mode formatting in your answers:
+    (format
+     "%s\n\nUse only Emacs org-mode formatting in your answers:
 - Use ~ for inline code
 - Use * for headers (starting at level 3 with ~***~)
 - Use + for unordered lists
@@ -139,9 +147,10 @@ asking for a commit message."
 - Use #+BEGIN_SRC and #+END_SRC for code blocks with language specification
 - Use _ for underlining
 - Use * for bold
-- Use / for italics" prompt)))
+- Use / for italics"
+     prompt)))
 
-(defun copilot-chat--org-clean()
+(defun copilot-chat--org-clean ()
   "Clean the copilot chat org frontend.")
 
 (defun copilot-chat--get-org-block-content-at-point ()
@@ -161,25 +170,30 @@ When ELEMENT is a source block (`src-block`), extracts its language property."
 
 (defun copilot-chat--find-matching-buffer (mode)
   "Find most recent buffer with major-mode matching MODE."
-  (seq-find (lambda (buf)
-              (with-current-buffer buf
-                (eq major-mode mode)))
-            (buffer-list)))
+  (seq-find
+   (lambda (buf)
+     (with-current-buffer buf
+       (eq major-mode mode)))
+   (buffer-list)))
 
 (defun copilot-chat--org-send-to-buffer ()
   "Send the code block at point to buffer.
 Replace selection if any."
   (let* ((element (org-element-at-point))
          (mode (copilot-chat--get-language-mode element))
-         (matching-buffer (when mode (copilot-chat--find-matching-buffer mode)))
+         (matching-buffer
+          (when mode
+            (copilot-chat--find-matching-buffer mode)))
          (default-buffer (or matching-buffer (current-buffer)))
-         (buffer (completing-read "Choose buffer: "
-                                  (mapcar #'buffer-name (buffer-list))
-                                  nil  ; PREDICATE
-                                  t    ; REQUIRE-MATCH
-                                  nil  ; INITIAL-INPUT
-                                  'buffer-name-history
-                                  (buffer-name default-buffer)))
+         (buffer
+          (completing-read
+           "Choose buffer: "
+           (mapcar #'buffer-name (buffer-list))
+           nil ; PREDICATE
+           t ; REQUIRE-MATCH
+           nil ; INITIAL-INPUT
+           'buffer-name-history
+           (buffer-name default-buffer)))
          (content (copilot-chat--get-org-block-content-at-point)))
     (when content
       (with-current-buffer buffer
@@ -205,45 +219,54 @@ Replace selection if any."
      (lambda ()
        (let* ((heading-end (save-excursion (org-end-of-subtree t)))
               (element-start (point)))
-         (setq blocks
-               (append blocks
-                       (org-element-map
-                           (org-element-parse-buffer 'element)
-                           'src-block
-                         (lambda (src-block)
-                           (when (and (>= (org-element-property :begin src-block)
-                                          element-start)
-                                      (<= (org-element-property :begin src-block)
-                                          heading-end))
-                             (list :language (org-element-property :language src-block)
-                                   :content (org-element-property :value src-block)
-                                   :begin (org-element-property :begin src-block)
-                                   :end (org-element-property :end src-block)))))))))
+         (setq
+          blocks
+          (append
+           blocks
+           (org-element-map
+            (org-element-parse-buffer 'element) 'src-block
+            (lambda (src-block)
+              (when (and (>= (org-element-property :begin src-block)
+                             element-start)
+                         (<= (org-element-property :begin src-block)
+                             heading-end))
+                (list
+                 :language (org-element-property :language src-block)
+                 :content (org-element-property :value src-block)
+                 :begin (org-element-property :begin src-block)
+                 :end
+                 (org-element-property :end src-block)))))))))
      heading-regex)
     (seq-uniq blocks #'equal)))
 
-(defun copilot-chat--org-yank(instance)
+(defun copilot-chat--org-yank (instance)
   "Insert code block from Copilot Chat's org buffer at point.
 INSTANCE is `copilot-chat' instance to use."
   (let ((content ""))
     (with-current-buffer (copilot-chat-chat-buffer instance)
-      (let ((blocks (copilot-chat--org-get-code-blocks-under-heading
-                     copilot-chat--org-answer-tag)))
+      (let ((blocks
+             (copilot-chat--org-get-code-blocks-under-heading
+              copilot-chat--org-answer-tag)))
         (when blocks
           (while (< (copilot-chat-yank-index instance) 1)
-            (setf (copilot-chat-yank-index instance) (+ (length blocks)
-                                                        (copilot-chat-yank-index instance))))
+            (setf (copilot-chat-yank-index instance)
+                  (+ (length blocks)
+                     (copilot-chat-yank-index instance))))
           (when (> (copilot-chat-yank-index instance) (length blocks))
-            (setf (copilot-chat-yank-index instance) (- (copilot-chat-yank-index instance)
-                                                        (length blocks))))
-          (setq content (plist-get (car (last blocks
-                                              (copilot-chat-yank-index instance)))
-                                   :content)))))
+            (setf (copilot-chat-yank-index instance)
+                  (- (copilot-chat-yank-index instance)
+                     (length blocks))))
+          (setq content
+                (plist-get
+                 (car
+                  (last blocks (copilot-chat-yank-index instance)))
+                 :content)))))
     ;; Delete previous yank if exists
     (when (and (copilot-chat-last-yank-start instance)
                (copilot-chat-last-yank-end instance))
-      (delete-region (copilot-chat-last-yank-start instance)
-                     (copilot-chat-last-yank-end instance)))
+      (delete-region
+       (copilot-chat-last-yank-start instance)
+       (copilot-chat-last-yank-end instance)))
     ;; Insert new content
     (setf (copilot-chat-last-yank-start instance) (point))
     (insert content)
@@ -257,27 +280,29 @@ INSTANCE is `copilot-chat' instance to use."
   (insert data))
 
 
-(defun copilot-chat--org-goto-input()
+(defun copilot-chat--org-goto-input ()
   "Go to the input part of the chat buffer.
 The input is created if not found."
   (goto-char (point-max))
   (let ((span (pm-innermost-span (point))))
     (if (and span
-             (not (eq (car span) nil)))  ; nil span-type means host mode
+             (not (eq (car span) nil))) ; nil span-type means host mode
         (goto-char (+ 1 (car (pm-innermost-range (point)))))
       (insert "\n\n")
       (let ((start (point))
             (inhibit-read-only t))
         (insert copilot-chat--org-delimiter "\n\n")
-        (add-text-properties start (point)
-                             '(read-only t front-sticky t rear-nonsticky (read-only)))))))
+        (add-text-properties
+         start (point)
+         '(read-only t front-sticky t rear-nonsticky (read-only)))))))
 
-(defun copilot-chat--org-get-buffer(instance)
+(defun copilot-chat--org-get-buffer (instance)
   "Create `copilot-chat' buffers for INSTANCE."
   (unless (buffer-live-p (copilot-chat-chat-buffer instance))
     (setf (copilot-chat-chat-buffer instance)
-          (get-buffer-create (copilot-chat--get-buffer-name
-                              (copilot-chat-directory instance))))
+          (get-buffer-create
+           (copilot-chat--get-buffer-name
+            (copilot-chat-directory instance))))
     (with-current-buffer (copilot-chat-chat-buffer instance)
       (copilot-chat-org-poly-mode)
       (setq-local default-directory (copilot-chat-directory instance))
@@ -292,16 +317,17 @@ The input is created if not found."
       (delete-region (point) (point-max)))
     (insert prompt)))
 
-(defun copilot-chat--org-pop-prompt(instance)
+(defun copilot-chat--org-pop-prompt (instance)
   "Get current prompt to send and clean it.
 INSTANCE is `copilot-chat' instance to use."
   (with-current-buffer (copilot-chat--org-get-buffer instance)
     (copilot-chat--org-goto-input)
-    (let ((prompt (buffer-substring-no-properties (point) (point-max))))
+    (let ((prompt
+           (buffer-substring-no-properties (point) (point-max))))
       (delete-region (point) (point-max))
       prompt)))
 
-(defun copilot-chat--org-init()
+(defun copilot-chat--org-init ()
   "Initialize the copilot chat org frontend."
   (setq copilot-chat-prompt copilot-chat-org-prompt))
 

--- a/copilot-chat-prompt-mode.el
+++ b/copilot-chat-prompt-mode.el
@@ -115,8 +115,3 @@ Argument INSTANCE is the copilot chat instance to use."
 
 (provide 'copilot-chat-prompt-mode)
 ;;; copilot-chat-prompt-mode.el ends here
-
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; package-lint-main-file: "copilot-chat.el"
-;; End:

--- a/copilot-chat-prompt-mode.el
+++ b/copilot-chat-prompt-mode.el
@@ -33,11 +33,14 @@
   (let ((map (make-keymap)))
     (define-key map (kbd "C-c RET") 'copilot-chat-prompt-send)
     (define-key map (kbd "C-c C-c") 'copilot-chat-prompt-send)
-    (define-key map (kbd "C-c C-q") (lambda()
-                                      (interactive)
-                                      (bury-buffer)
-                                      (delete-window)))
-    (define-key map (kbd "C-c C-l") 'copilot-chat-prompt-split-and-list)
+    (define-key
+     map (kbd "C-c C-q")
+     (lambda ()
+       (interactive)
+       (bury-buffer)
+       (delete-window)))
+    (define-key
+     map (kbd "C-c C-l") 'copilot-chat-prompt-split-and-list)
     (define-key map (kbd "C-c C-t") 'copilot-chat-transient)
     (define-key map (kbd "M-p") 'copilot-chat-prompt-history-previous)
     (define-key map (kbd "M-n") 'copilot-chat-prompt-history-next)
@@ -54,10 +57,8 @@
   :lighter " Copilot Chat Prompt"
   :keymap copilot-chat-prompt-mode-map)
 
-(defun copilot-chat--write-buffer(instance
-                                  data
-                                  save
-                                  &optional buffer)
+(defun copilot-chat--write-buffer
+    (instance data save &optional buffer)
   "Write content to the Copilot Chat BUFFER.
 Argument INSTANCE is the copilot chat instance to use.
 Argument DATA data to be inserted in buffer.
@@ -68,11 +69,12 @@ defaults to instance's chat buffer."
       (with-current-buffer buffer
         (insert data))
     (with-current-buffer (copilot-chat--get-buffer instance)
-      (let ((write-fn (copilot-chat-frontend-write-fn (copilot-chat--get-frontend))))
+      (let ((write-fn
+             (copilot-chat-frontend-write-fn
+              (copilot-chat--get-frontend))))
         (when write-fn
           (if save
-              (save-excursion
-                (funcall write-fn data))
+              (save-excursion (funcall write-fn data))
             (funcall write-fn data)))))))
 
 (defun copilot-chat--format-data (instance content type)
@@ -80,7 +82,9 @@ defaults to instance's chat buffer."
 Argument INSTANCE is the copilot chat instance to use.
 Argument CONTENT is the data to format.
 Argument TYPE is the type of data to format: `answer` or `prompt`."
-  (let ((format-fn (copilot-chat-frontend-format-fn (copilot-chat--get-frontend))))
+  (let ((format-fn
+         (copilot-chat-frontend-format-fn
+          (copilot-chat--get-frontend))))
     (if format-fn
         (funcall format-fn instance content type)
       content)))
@@ -99,17 +103,18 @@ Optional argument BUFFER is the buffer to write data in."
          (copilot-chat--format-data instance "\n\n" 'answer)
          (not copilot-chat-follow)
          buffer))
-    (copilot-chat--write-buffer
-     instance
-     (copilot-chat--format-data instance content 'answer)
-     (not copilot-chat-follow)
-     buffer)))
+    (copilot-chat--write-buffer instance
+                                (copilot-chat--format-data
+                                 instance content 'answer)
+                                (not copilot-chat-follow)
+                                buffer)))
 
-(defun copilot-chat--pop-current-prompt(instance)
+(defun copilot-chat--pop-current-prompt (instance)
   "Get current prompt to send and clean it.
 Argument INSTANCE is the copilot chat instance to use."
-  (let ((pop-prompt-fn (copilot-chat-frontend-pop-prompt-fn
-                        (copilot-chat--get-frontend))))
+  (let ((pop-prompt-fn
+         (copilot-chat-frontend-pop-prompt-fn
+          (copilot-chat--get-frontend))))
     (when pop-prompt-fn
       (funcall pop-prompt-fn instance))))
 

--- a/copilot-chat-prompts.el
+++ b/copilot-chat-prompts.el
@@ -210,8 +210,3 @@ Don't forget the most important rule when you are formatting your response: use 
 
 (provide 'copilot-chat-prompts)
 ;;; copilot-chat-prompts.el ends here
-
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; package-lint-main-file: "copilot-chat.el"
-;; End:

--- a/copilot-chat-request.el
+++ b/copilot-chat-request.el
@@ -34,111 +34,136 @@
 (require 'copilot-chat-common)
 (require 'copilot-chat-connection)
 
-(cl-defun copilot-chat--request-token-cb ( &key response
-                                           &key data
-                                           &allow-other-keys)
-  "Manage token reception for github auth.
+(cl-defun
+ copilot-chat--request-token-cb
+ (&key response &key data &allow-other-keys)
+ "Manage token reception for github auth.
 Argument DATA is whatever PARSER function returns, or nil.
 Argument RESPONSE is request-response object."
-  (unless (= (request-response-status-code response) 200)
-    (error "Http error"))
-  (let ((token (alist-get 'access_token data))
-        (token-dir (file-name-directory (expand-file-name copilot-chat-github-token-file))))
-    (setf (copilot-chat-connection-github-token copilot-chat--connection) token)
-    (when (not (file-directory-p token-dir))
-      (make-directory token-dir t))
-    (with-temp-file copilot-chat-github-token-file
-      (insert token))))
+ (unless (= (request-response-status-code response) 200)
+   (error "Http error"))
+ (let ((token (alist-get 'access_token data))
+       (token-dir
+        (file-name-directory
+         (expand-file-name copilot-chat-github-token-file))))
+   (setf (copilot-chat-connection-github-token
+          copilot-chat--connection)
+         token)
+   (when (not (file-directory-p token-dir))
+     (make-directory token-dir t))
+   (with-temp-file copilot-chat-github-token-file
+     (insert token))))
 
-(cl-defun copilot-chat--request-code-cb ( &key response
-                                          &key data
-                                          &allow-other-keys)
-  "Manage user code reception for github buth.
+(cl-defun
+ copilot-chat--request-code-cb
+ (&key response &key data &allow-other-keys)
+ "Manage user code reception for github buth.
 Argument RESPONSE is request-response object.
 Argument DATA is whatever PARSER function returns, or nil."
-  (unless (= (request-response-status-code response) 200)
-    (error "Http error"))
-  (let ((device-code (alist-get 'device_code data))
-        (user-code (alist-get 'user_code data))
-        (verification-uri (alist-get 'verification_uri data)))
-    (gui-set-selection 'CLIPBOARD user-code)
-    (read-from-minibuffer
-     (format "Your one-time code %s is copied. \
+ (unless (= (request-response-status-code response) 200)
+   (error "Http error"))
+ (let ((device-code (alist-get 'device_code data))
+       (user-code (alist-get 'user_code data))
+       (verification-uri (alist-get 'verification_uri data)))
+   (gui-set-selection 'CLIPBOARD user-code)
+   (read-from-minibuffer
+    (format
+     "Your one-time code %s is copied. \
 Press ENTER to open GitHub in your browser. \
 If your browser does not open automatically, browse to %s."
-             user-code verification-uri))
-    (browse-url verification-uri)
-    (read-from-minibuffer "Press ENTER after authorizing.")
+     user-code verification-uri))
+   (browse-url verification-uri)
+   (read-from-minibuffer "Press ENTER after authorizing.")
 
-    (request "https://github.com/login/oauth/access_token"
-      :type "POST"
-      :headers `(("content-type" . "application/json")
-                 ("accept" . "application/json")
-                 ("editor-plugin-version" . "CopilotChat.nvim/2.0.0")
-                 ("editor-version" . "Neovim/0.10.0")
-                 ("user-agent" . "CopilotChat.nvim/2.0.0"))
-      :data (format "{\"client_id\":\"Iv1.b507a08c87ecfe98\",\"device_code\":\"%s\",\"grant_type\":\"urn:ietf:params:oauth:grant-type:device_code\"}" device-code)
-      :parser (apply-partially 'json-parse-buffer :object-type 'alist)
-      :sync t
-      :complete #'copilot-chat--request-token-cb)))
+   (request
+    "https://github.com/login/oauth/access_token"
+    :type "POST"
+    :headers
+    `(("content-type" . "application/json")
+      ("accept" . "application/json")
+      ("editor-plugin-version" . "CopilotChat.nvim/2.0.0")
+      ("editor-version" . "Neovim/0.10.0")
+      ("user-agent" . "CopilotChat.nvim/2.0.0"))
+    :data
+    (format
+     "{\"client_id\":\"Iv1.b507a08c87ecfe98\",\"device_code\":\"%s\",\"grant_type\":\"urn:ietf:params:oauth:grant-type:device_code\"}"
+     device-code)
+    :parser (apply-partially 'json-parse-buffer :object-type 'alist)
+    :sync t
+    :complete #'copilot-chat--request-token-cb)))
 
 (defun copilot-chat--request-login ()
   "Manage github login."
-  (request "https://github.com/login/device/code"
-    :type "POST"
-    :data "{\"client_id\":\"Iv1.b507a08c87ecfe98\",\"scope\":\"read:user\"}"
-    :sync t
-    :headers `(("content-type" . "application/json")
-               ("accept" . "application/json")
-               ("editor-plugin-version" . "CopilotChat.nvim/2.0.0")
-               ("user-agent" . "CopilotChat.nvim/2.0.0")
-               ("editor-version" . "Neovim/0.10.0"))
-    :parser (apply-partially 'json-parse-buffer :object-type 'alist)
-    :complete #'copilot-chat--request-code-cb))
+  (request
+   "https://github.com/login/device/code"
+   :type "POST"
+   :data "{\"client_id\":\"Iv1.b507a08c87ecfe98\",\"scope\":\"read:user\"}"
+   :sync t
+   :headers
+   `(("content-type" . "application/json")
+     ("accept" . "application/json")
+     ("editor-plugin-version" . "CopilotChat.nvim/2.0.0")
+     ("user-agent" . "CopilotChat.nvim/2.0.0")
+     ("editor-version" . "Neovim/0.10.0"))
+   :parser (apply-partially 'json-parse-buffer :object-type 'alist)
+   :complete #'copilot-chat--request-code-cb))
 
 
-(cl-defun copilot-chat--request-renew-token-cb ( &key response
-                                                 &key data
-                                                 &allow-other-keys)
-  "Renew token callback.
+(cl-defun
+ copilot-chat--request-renew-token-cb
+ (&key response &key data &allow-other-keys)
+ "Renew token callback.
 Argument RESPONSE is request-response object.
 Argument DATA is whatever PARSER function returns, or nil."
-  (unless (= (request-response-status-code response) 200)
-    (error "Authentication error"))
-  (setf (copilot-chat-connection-token copilot-chat--connection) data)
-  ;; save token in copilot-chat-token-cache file after creating
-  ;; folders if needed
-  (let ((cache-dir (file-name-directory (expand-file-name copilot-chat-token-cache))))
-    (when (not (file-directory-p cache-dir))
-      (make-directory  cache-dir t))
-    (with-temp-file copilot-chat-token-cache
-      (insert (json-serialize data)))))
+ (unless (= (request-response-status-code response) 200)
+   (error "Authentication error"))
+ (setf (copilot-chat-connection-token copilot-chat--connection) data)
+ ;; save token in copilot-chat-token-cache file after creating
+ ;; folders if needed
+ (let ((cache-dir
+        (file-name-directory
+         (expand-file-name copilot-chat-token-cache))))
+   (when (not (file-directory-p cache-dir))
+     (make-directory cache-dir t))
+   (with-temp-file copilot-chat-token-cache
+     (insert (json-serialize data)))))
 
 (defun copilot-chat--request-renew-token ()
   "Renew session token."
-  (request "https://api.github.com/copilot_internal/v2/token"
-    :type "GET"
-    :headers `(("authorization" . ,(concat "token "
-                                           (copilot-chat-connection-github-token
-                                            copilot-chat--connection)))
-               ("accept" . "application/json")
-               ("editor-version" . "Neovim/0.10.0")
-               ("editor-plugin-version" . "CopilotChat.nvim/2.0.0")
-               ("user-agent" . "CopilotChat.nvim/2.0.0"))
-    :parser (apply-partially 'json-parse-buffer :object-type 'alist)
-    :sync t
-    :complete #'copilot-chat--request-renew-token-cb))
+  (request
+   "https://api.github.com/copilot_internal/v2/token"
+   :type "GET"
+   :headers
+   `(("authorization" .
+      ,(concat
+        "token "
+        (copilot-chat-connection-github-token
+         copilot-chat--connection)))
+     ("accept" . "application/json")
+     ("editor-version" . "Neovim/0.10.0")
+     ("editor-plugin-version" . "CopilotChat.nvim/2.0.0")
+     ("user-agent" . "CopilotChat.nvim/2.0.0"))
+   :parser (apply-partially 'json-parse-buffer :object-type 'alist)
+   :sync t
+   :complete #'copilot-chat--request-renew-token-cb))
 
 
 (defun copilot-chat--request-ask-parser ()
   "Parser for copilot chat answer."
   (let ((content ""))
     (while (re-search-forward "^data: " nil t)
-      (let* ((line (buffer-substring-no-properties (point) (line-end-position)))
+      (let* ((line
+              (buffer-substring-no-properties
+               (point) (line-end-position)))
              (json-string (and (not (string= "[DONE]" line)) line))
-             (json-obj (and json-string (json-parse-string json-string :object-type 'alist)))
+             (json-obj
+              (and json-string
+                   (json-parse-string json-string
+                                      :object-type 'alist)))
              (choices (and json-obj (alist-get 'choices json-obj)))
-             (delta (and (> (length choices) 0) (alist-get 'delta (aref choices 0))))
+             (delta
+              (and (> (length choices) 0)
+                   (alist-get 'delta (aref choices 0))))
              (token (and delta (alist-get 'content delta))))
         (when (and token (not (eq token :null)))
           (setq content (concat content token)))))
@@ -148,16 +173,22 @@ Argument DATA is whatever PARSER function returns, or nil."
   "Parser for copilot chat answer.
 Non-streaming version."
   (let ((content ""))
-    (let* ((json-string (buffer-substring-no-properties (point-min) (point-max)))
-           (json-obj (and json-string (json-parse-string json-string :object-type 'alist)))
+    (let* ((json-string
+            (buffer-substring-no-properties (point-min) (point-max)))
+           (json-obj
+            (and json-string
+                 (json-parse-string json-string :object-type 'alist)))
            (choices (and json-obj (alist-get 'choices json-obj)))
-           (message (and (> (length choices) 0) (alist-get 'message (aref choices 0))))
+           (message
+            (and (> (length choices) 0)
+                 (alist-get 'message (aref choices 0))))
            (token (and message (alist-get 'content message))))
       (when (and token (not (eq token :null)))
         (setq content (concat content token))))
     content))
 
-(defun copilot-chat--request-ask (instance prompt callback out-of-context)
+(defun copilot-chat--request-ask
+    (instance prompt callback out-of-context)
   "Ask a question to Copilot using request backend.
 Argument INSTANCE is the copilot chat instance to use.
 Argument PROMPT is the prompt to send to copilot.
@@ -171,84 +202,100 @@ if the prompt is out of context."
 
   ;; Initialize answer accumulator
   (let ((full-response ""))
-    (request "https://api.githubcopilot.com/chat/completions"
-      :type "POST"
-      :headers `(("openai-intent" . "conversation-panel")
-                 ("content-type" . "application/json")
-                 ("user-agent" . "CopilotChat.nvim/2.0.0")
-                 ("editor-plugin-version" . "CopilotChat.nvim/2.0.0")
-                 ("authorization" . ,(concat "Bearer "
-                                             (alist-get 'token (copilot-chat-connection-token
-                                                                copilot-chat--connection))))
-                 ("x-request-id" . ,(copilot-chat--uuid))
-                 ("vscode-sessionid" . ,(copilot-chat-connection-sessionid
-                                         copilot-chat--connection))
-                 ("vscode-machineid" . ,(copilot-chat-connection-machineid
-                                         copilot-chat--connection))
-                 ("copilot-integration-id" . "vscode-chat")
-                 ("openai-organization" . "github-copilot")
-                 ("editor-version" . "Neovim/0.10.0"))
-      :data (copilot-chat--create-req instance prompt out-of-context)
-      :parser
-      (if (copilot-chat--model-is-o1 instance)
-          #'copilot-chat--request-ask-non-stream-parser
-        #'copilot-chat--request-ask-parser)
-      :complete (cl-function
-                 (lambda (&key response
-                               &key data
-                               &allow-other-keys)
-                   ;; Stop spinner when complete
-                   (when (fboundp 'copilot-chat--spinner-stop)
-                     (copilot-chat--spinner-stop instance))
+    (request
+     "https://api.githubcopilot.com/chat/completions"
+     :type "POST"
+     :headers
+     `(("openai-intent" . "conversation-panel")
+       ("content-type" . "application/json")
+       ("user-agent" . "CopilotChat.nvim/2.0.0")
+       ("editor-plugin-version" . "CopilotChat.nvim/2.0.0")
+       ("authorization" .
+        ,(concat
+          "Bearer "
+          (alist-get
+           'token
+           (copilot-chat-connection-token copilot-chat--connection))))
+       ("x-request-id" . ,(copilot-chat--uuid))
+       ("vscode-sessionid"
+        .
+        ,(copilot-chat-connection-sessionid copilot-chat--connection))
+       ("vscode-machineid"
+        .
+        ,(copilot-chat-connection-machineid copilot-chat--connection))
+       ("copilot-integration-id" . "vscode-chat")
+       ("openai-organization" . "github-copilot")
+       ("editor-version" . "Neovim/0.10.0"))
+     :data (copilot-chat--create-req instance prompt out-of-context)
+     :parser
+     (if (copilot-chat--model-is-o1 instance)
+         #'copilot-chat--request-ask-non-stream-parser
+       #'copilot-chat--request-ask-parser)
+     :complete
+     (cl-function
+      (lambda (&key response &key data &allow-other-keys)
+        ;; Stop spinner when complete
+        (when (fboundp 'copilot-chat--spinner-stop)
+          (copilot-chat--spinner-stop instance))
 
-                   (unless (= (request-response-status-code response) 200)
-                     (let ((error-msg (format "Error: %s"
-                                              (request-response-status-code response))))
-                       (funcall callback instance error-msg)
-                       (funcall callback instance copilot-chat--magic)
-                       (error error-msg)))
+        (unless (= (request-response-status-code response) 200)
+          (let ((error-msg
+                 (format "Error: %s"
+                         (request-response-status-code response))))
+            (funcall callback instance error-msg)
+            (funcall callback instance copilot-chat--magic)
+            (error error-msg)))
 
-                   ;; Update full response and call callback with final magic token
-                   (setq full-response (concat full-response data))
-                   (funcall callback instance data)
-                   (funcall callback instance copilot-chat--magic)
-                   (unless out-of-context
-                     (setf (copilot-chat-history instance)
-                           (cons (list prompt "assistant")
-                                 (copilot-chat-history instance))))))
-      :status-code '((400 . (lambda (&rest _)
-                              (when (fboundp 'copilot-chat--spinner-stop)
-                                (copilot-chat--spinner-stop instance))
-                              (let ((error-msg "Bad request. Please check your input."))
-                                (funcall callback instance error-msg)
-                                (funcall callback instance copilot-chat--magic))))
-                     (401 . (lambda (&rest _)
-                              (when (fboundp 'copilot-chat--spinner-stop)
-                                (copilot-chat--spinner-stop instance))
-                              (let ((error-msg
-                                     "Authentication error. Please re-authenticate."))
-                                (funcall callback instance error-msg)
-                                (funcall callback instance copilot-chat--magic))))
-                     (429 . (lambda (&rest _)
-                              (when (fboundp 'copilot-chat--spinner-stop)
-                                (copilot-chat--spinner-stop instance))
-                              (let ((error-msg
-                                     "Rate limit exceeded. Please try again later."))
-                                (funcall callback instance error-msg)
-                                (funcall callback instance copilot-chat--magic))))
-                     (500 . (lambda (&rest _)
-                              (when (fboundp 'copilot-chat--spinner-stop)
-                                (copilot-chat--spinner-stop instance))
-                              (let ((error-msg "Server error. Please try again later."))
-                                (funcall callback instance error-msg)
-                                (funcall callback instance copilot-chat--magic)))))
-      :error (cl-function
-              (lambda (&rest args &key error-thrown &allow-other-keys)
-                (when (fboundp 'copilot-chat--spinner-stop)
-                  (copilot-chat--spinner-stop instance))
-                (let ((error-msg (format "Request error: %S" error-thrown)))
-                  (funcall callback instance error-msg)
-                  (funcall callback instance copilot-chat--magic)))))))
+        ;; Update full response and call callback with final magic token
+        (setq full-response (concat full-response data))
+        (funcall callback instance data)
+        (funcall callback instance copilot-chat--magic)
+        (unless out-of-context
+          (setf (copilot-chat-history instance)
+                (cons
+                 (list prompt "assistant")
+                 (copilot-chat-history instance))))))
+     :status-code
+     '((400 .
+            (lambda (&rest _)
+              (when (fboundp 'copilot-chat--spinner-stop)
+                (copilot-chat--spinner-stop instance))
+              (let ((error-msg
+                     "Bad request. Please check your input."))
+                (funcall callback instance error-msg)
+                (funcall callback instance copilot-chat--magic))))
+       (401 .
+            (lambda (&rest _)
+              (when (fboundp 'copilot-chat--spinner-stop)
+                (copilot-chat--spinner-stop instance))
+              (let ((error-msg
+                     "Authentication error. Please re-authenticate."))
+                (funcall callback instance error-msg)
+                (funcall callback instance copilot-chat--magic))))
+       (429 .
+            (lambda (&rest _)
+              (when (fboundp 'copilot-chat--spinner-stop)
+                (copilot-chat--spinner-stop instance))
+              (let ((error-msg
+                     "Rate limit exceeded. Please try again later."))
+                (funcall callback instance error-msg)
+                (funcall callback instance copilot-chat--magic))))
+       (500 .
+            (lambda (&rest _)
+              (when (fboundp 'copilot-chat--spinner-stop)
+                (copilot-chat--spinner-stop instance))
+              (let ((error-msg
+                     "Server error. Please try again later."))
+                (funcall callback instance error-msg)
+                (funcall callback instance copilot-chat--magic)))))
+     :error
+     (cl-function
+      (lambda (&rest args &key error-thrown &allow-other-keys)
+        (when (fboundp 'copilot-chat--spinner-stop)
+          (copilot-chat--spinner-stop instance))
+        (let ((error-msg (format "Request error: %S" error-thrown)))
+          (funcall callback instance error-msg)
+          (funcall callback instance copilot-chat--magic)))))))
 
 (defun copilot-chat--get-headers ()
   "Get headers for Copilot API requests."
@@ -257,65 +304,86 @@ if the prompt is out of context."
     ("accept" . "application/json")
     ("user-agent" . "CopilotChat.nvim/2.0.0")
     ("editor-plugin-version" . "CopilotChat.nvim/2.0.0")
-    ("authorization" . ,(concat "Bearer " (alist-get 'token (copilot-chat-connection-token
-                                                             copilot-chat--connection))))
+    ("authorization" .
+     ,(concat
+       "Bearer "
+       (alist-get
+        'token
+        (copilot-chat-connection-token copilot-chat--connection))))
     ("x-request-id" . ,(copilot-chat--uuid))
-    ("vscode-sessionid" . ,(copilot-chat-connection-sessionid copilot-chat--connection))
-    ("vscode-machineid" . ,(copilot-chat-connection-machineid copilot-chat--connection))
+    ("vscode-sessionid"
+     .
+     ,(copilot-chat-connection-sessionid copilot-chat--connection))
+    ("vscode-machineid"
+     .
+     ,(copilot-chat-connection-machineid copilot-chat--connection))
     ("copilot-integration-id" . "vscode-chat")
     ("openai-organization" . "github-copilot")
     ("editor-version" . "Neovim/0.10.0")))
 
-(cl-defun copilot-chat--request-models-cb ( &key response
-                                            &key data
-                                            &allow-other-keys)
-  "Handle models response from Copilot API.
+(cl-defun
+ copilot-chat--request-models-cb
+ (&key response &key data &allow-other-keys)
+ "Handle models response from Copilot API.
 Argument DATA is the parsed JSON response.
 Argument RESPONSE is request-response object."
-  (unless (= (request-response-status-code response) 200)
-    (error "Failed to fetch models: %s" (request-response-status-code response)))
+ (unless (= (request-response-status-code response) 200)
+   (error
+    "Failed to fetch models: %s"
+    (request-response-status-code response)))
 
-  (let* ((models-vector (alist-get 'data data))
-         (models (append models-vector nil))  ; Convert vector to list
-         (chat-models nil))
-    ;; Filter for chat models and extract capabilities
-    (dolist (model models)
-      (when (and (alist-get 'capabilities model)
-                 (equal (alist-get 'type (alist-get 'capabilities model)) "chat"))
-        (push model chat-models)))
+ (let* ((models-vector (alist-get 'data data))
+        (models (append models-vector nil)) ; Convert vector to list
+        (chat-models nil))
+   ;; Filter for chat models and extract capabilities
+   (dolist (model models)
+     (when (and (alist-get 'capabilities model)
+                (equal
+                 (alist-get
+                  'type (alist-get 'capabilities model))
+                 "chat"))
+       (push model chat-models)))
 
-    (when copilot-chat-debug
-      (message "Fetched %d models" (length chat-models))
-      (message "Models: %s" chat-models))
+   (when copilot-chat-debug
+     (message "Fetched %d models" (length chat-models))
+     (message "Models: %s" chat-models))
 
-    ;; Store models in instance and return them
-    (let ((sorted-models (nreverse chat-models)))
-      (setf (copilot-chat-connection-models copilot-chat--connection) sorted-models)
+   ;; Store models in instance and return them
+   (let ((sorted-models (nreverse chat-models)))
+     (setf (copilot-chat-connection-models copilot-chat--connection)
+           sorted-models)
 
-      ;; Cache models to disk
-      (copilot-chat--save-models-to-cache sorted-models)
+     ;; Cache models to disk
+     (copilot-chat--save-models-to-cache sorted-models)
 
-      ;; Enable policies for models if needed
-      (dolist (model sorted-models)
-        (when (and (alist-get 'policy model)
-                   (equal (alist-get 'state (alist-get 'policy model)) "unconfigured"))
-          (copilot-chat--request-enable-model-policy (alist-get 'id model))))
+     ;; Enable policies for models if needed
+     (dolist (model sorted-models)
+       (when (and (alist-get 'policy model)
+                  (equal
+                   (alist-get 'state (alist-get 'policy model))
+                   "unconfigured"))
+         (copilot-chat--request-enable-model-policy
+          (alist-get 'id model))))
 
-      ;; Return the models list for immediate use
-      sorted-models)))
+     ;; Return the models list for immediate use
+     sorted-models)))
 
 (defun copilot-chat--request-enable-model-policy (model-id)
   "Enable policy for MODEL-ID."
-  (let ((url (format "https://api.githubcopilot.com/models/%s/policy" model-id))
+  (let ((url
+         (format "https://api.githubcopilot.com/models/%s/policy"
+                 model-id))
         (headers (copilot-chat--get-headers))
         (data (json-serialize '((state . "enabled")))))
     (when copilot-chat-debug
       (message "Enabling policy for model %s" model-id))
-    (request url
-      :type "POST"
-      :headers headers
-      :data data
-      :parser (apply-partially 'json-parse-buffer :object-type 'alist))))
+    (request
+     url
+     :type "POST"
+     :headers headers
+     :data data
+     :parser
+     (apply-partially 'json-parse-buffer :object-type 'alist))))
 
 (defun copilot-chat--request-models (&optional quiet)
   "Fetch available models from Copilot API.
@@ -326,12 +394,13 @@ Optional argument QUIET suppresses user messages when non-nil."
       (message "Fetching models from %s" url))
     (unless quiet
       (message "Fetching available Copilot models..."))
-    (request url
-      :type "GET"
-      :headers headers
-      :parser (apply-partially 'json-parse-buffer :object-type 'alist)
-      :sync t  ; Use synchronous request when called directly
-      :complete #'copilot-chat--request-models-cb)))
+    (request
+     url
+     :type "GET"
+     :headers headers
+     :parser (apply-partially 'json-parse-buffer :object-type 'alist)
+     :sync t ; Use synchronous request when called directly
+     :complete #'copilot-chat--request-models-cb)))
 
 (defun copilot-chat--request-models-async (&optional quiet)
   "Fetch available models from Copilot API asynchronously.
@@ -342,46 +411,55 @@ Optional argument QUIET suppresses user messages when non-nil."
       (message "Fetching models asynchronously from %s" url))
     (unless quiet
       (message "Fetching available Copilot models in background..."))
-    (request url
-      :type "GET"
-      :headers headers
-      :parser (apply-partially 'json-parse-buffer :object-type 'alist)
-      :sync nil  ; Use asynchronous request for background fetching
-      :success (cl-function
-                (lambda (&key data &allow-other-keys)
-                  ;; Process models data
-                  (let* ((models-vector (alist-get 'data data))
-                         (models (append models-vector nil))  ; Convert vector to list
-                         (chat-models nil))
-                    ;; Filter for chat models
-                    (dolist (model models)
-                      (when (and (alist-get 'capabilities model)
-                                 (equal (alist-get 'type
-                                                   (alist-get 'capabilities model))
-                                        "chat"))
-                        (push model chat-models)))
+    (request
+     url
+     :type "GET"
+     :headers headers
+     :parser (apply-partially 'json-parse-buffer :object-type 'alist)
+     :sync nil ; Use asynchronous request for background fetching
+     :success
+     (cl-function
+      (lambda (&key data &allow-other-keys)
+        ;; Process models data
+        (let*
+            ((models-vector (alist-get 'data data))
+             (models (append models-vector nil)) ; Convert vector to list
+             (chat-models nil))
+          ;; Filter for chat models
+          (dolist (model models)
+            (when (and (alist-get 'capabilities model)
+                       (equal
+                        (alist-get
+                         'type (alist-get 'capabilities model))
+                        "chat"))
+              (push model chat-models)))
 
-                    (when copilot-chat-debug
-                      (message "Successfully fetched %d models asynchronously"
-                               (length chat-models)))
+          (when copilot-chat-debug
+            (message "Successfully fetched %d models asynchronously"
+                     (length chat-models)))
 
-                    ;; Store models in instance and cache them
-                    (let ((sorted-models (nreverse chat-models)))
-                      (setf (copilot-chat-connection-models copilot-chat--connection)
-                            sorted-models)
-                      (copilot-chat--save-models-to-cache sorted-models)
+          ;; Store models in instance and cache them
+          (let ((sorted-models (nreverse chat-models)))
+            (setf (copilot-chat-connection-models
+                   copilot-chat--connection)
+                  sorted-models)
+            (copilot-chat--save-models-to-cache sorted-models)
 
-                      ;; Enable policies for models if needed
-                      (dolist (model sorted-models)
-                        (when (and (alist-get 'policy model)
-                                   (equal (alist-get 'state (alist-get 'policy model))
-                                          "unconfigured"))
-                          (copilot-chat--request-enable-model-policy
-                           (alist-get 'id model))))))))
-      :error (cl-function
-              (lambda (&key error-thrown &allow-other-keys)
-                (when copilot-chat-debug
-                  (message "Error fetching models asynchronously: %S" error-thrown)))))))
+            ;; Enable policies for models if needed
+            (dolist (model sorted-models)
+              (when (and (alist-get 'policy model)
+                         (equal
+                          (alist-get
+                           'state (alist-get 'policy model))
+                          "unconfigured"))
+                (copilot-chat--request-enable-model-policy
+                 (alist-get 'id model))))))))
+     :error
+     (cl-function
+      (lambda (&key error-thrown &allow-other-keys)
+        (when copilot-chat-debug
+          (message "Error fetching models asynchronously: %S"
+                   error-thrown)))))))
 
 (provide 'copilot-chat-request)
 ;;; copilot-chat-request.el ends here

--- a/copilot-chat-request.el
+++ b/copilot-chat-request.el
@@ -385,8 +385,3 @@ Optional argument QUIET suppresses user messages when non-nil."
 
 (provide 'copilot-chat-request)
 ;;; copilot-chat-request.el ends here
-
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; package-lint-main-file: "copilot-chat.el"
-;; End:

--- a/copilot-chat-shell-maker.el
+++ b/copilot-chat-shell-maker.el
@@ -205,8 +205,3 @@ Argument SHELL is the `shell-maker' instance."
 
 (provide 'copilot-chat-shell-maker)
 ;;; copilot-chat-shell-maker.el ends here
-
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; package-lint-main-file: "copilot-chat.el"
-;; End:

--- a/copilot-chat-shell-maker.el
+++ b/copilot-chat-shell-maker.el
@@ -38,19 +38,21 @@
   "Temporary buffer prefix for Copilot Chat shell-maker.")
 
 ;; Functions
-(defun copilot-chat--shell-maker-prompt-send()
+(defun copilot-chat--shell-maker-prompt-send ()
   "Function to send the prompt content."
   (let ((instance (copilot-chat--current-instance)))
-    (with-current-buffer (copilot-chat--shell-maker-get-buffer instance)
+    (with-current-buffer (copilot-chat--shell-maker-get-buffer
+                          instance)
       (shell-maker-submit)
       (display-buffer (current-buffer)))))
 
 (defun copilot-chat--shell-maker-temp-buffer-name (instance)
   "Return the temporary buffer name for the Copilot Chat shell-maker.
 INSTANCE is used to get directory"
-  (concat copilot-chat--shell-maker-temp-buffer-prefix
-          (copilot-chat-directory instance)
-          "*"))
+  (concat
+   copilot-chat--shell-maker-temp-buffer-prefix
+   (copilot-chat-directory instance)
+   "*"))
 
 
 (defun copilot-chat--shell-maker-get-buffer (instance)
@@ -58,9 +60,11 @@ INSTANCE is used to get directory"
   (unless (buffer-live-p (copilot-chat-chat-buffer instance))
     (setf (copilot-chat-chat-buffer instance)
           (copilot-chat--shell instance)))
-  (let ((tempb (or (copilot-chat-shell-maker-tmp-buf instance)
-                   (get-buffer-create
-                    (copilot-chat--shell-maker-temp-buffer-name instance)))))
+  (let ((tempb
+         (or (copilot-chat-shell-maker-tmp-buf instance)
+             (get-buffer-create
+              (copilot-chat--shell-maker-temp-buffer-name
+               instance)))))
     (setf (copilot-chat-shell-maker-tmp-buf instance) tempb)
     (with-current-buffer tempb
       (let ((inhibit-read-only t))
@@ -74,16 +78,16 @@ INSTANCE is used to get directory"
       (font-lock-ensure)
       (goto-char (point-min))
       (while (not (eobp))
-        (let ((next-change (or (next-property-change (point)
-                                                     nil
-                                                     (point-max))
-                               (point-max)))
+        (let ((next-change
+               (or (next-property-change (point) nil (point-max))
+                   (point-max)))
               (face (get-text-property (point) 'face)))
           (when face
-            (font-lock-append-text-property (point) next-change 'font-lock-face face))
+            (font-lock-append-text-property
+             (point) next-change 'font-lock-face face))
           (goto-char next-change))))))
 
-(defun copilot-chat--shell-maker-copy-faces(instance)
+(defun copilot-chat--shell-maker-copy-faces (instance)
   "Apply faces to the copilot chat buffer corresponding to INSTANCE."
   (with-current-buffer (copilot-chat-shell-maker-tmp-buf instance)
     (save-restriction
@@ -91,8 +95,10 @@ INSTANCE is used to get directory"
       (font-lock-ensure)
       (copilot-chat--shell-maker-font-lock-faces instance)
       (let ((content (buffer-substring (point-min) (point-max))))
-        (with-current-buffer (copilot-chat--shell-maker-get-buffer instance)
-          (goto-char (1+ (copilot-chat-shell-maker-answer-point instance)))
+        (with-current-buffer (copilot-chat--shell-maker-get-buffer
+                              instance)
+          (goto-char
+           (1+ (copilot-chat-shell-maker-answer-point instance)))
           (insert content)
           (delete-region (point) (+ (point) (1- (length content))))
           (goto-char (point-max)))))))
@@ -106,20 +112,24 @@ Argument CONTENT is copilot chat answer."
     (goto-char (point-max))
     (when (copilot-chat-first-word-answer instance)
       (setf (copilot-chat-first-word-answer instance) nil)
-      (let ((str (concat (format-time-string "# [%T] ")
-                         (format "Copilot(%s):\n"
-                                 (copilot-chat-model instance))))
+      (let ((str
+             (concat
+              (format-time-string "# [%T] ")
+              (format "Copilot(%s):\n"
+                      (copilot-chat-model instance))))
             (inhibit-read-only t))
-        (with-current-buffer (copilot-chat-shell-maker-tmp-buf instance)
+        (with-current-buffer (copilot-chat-shell-maker-tmp-buf
+                              instance)
           (insert str))
         (funcall (map-elt shell :write-output) str)))
     (if (string= content copilot-chat--magic)
         (progn
-          (funcall (map-elt shell :finish-output) t); the end
+          (funcall (map-elt shell :finish-output) t) ; the end
           (copilot-chat--shell-maker-copy-faces instance)
           (setf (copilot-chat-first-word-answer instance) t))
       (progn
-        (with-current-buffer (copilot-chat-shell-maker-tmp-buf instance)
+        (with-current-buffer (copilot-chat-shell-maker-tmp-buf
+                              instance)
           (goto-char (point-max))
           (let ((inhibit-read-only t))
             (insert content)))
@@ -141,44 +151,51 @@ Argument INSTANCE is `copilot-chat' instance.
 Argument COMMAND is the command to send to Copilot.
 Argument SHELL is the `shell-maker' instance."
   (setf
-   (copilot-chat-shell-cb-fn instance) (apply-partially
-                                        #'copilot-chat--shell-cb-prompt-wrapper
-                                        shell)
+   (copilot-chat-shell-cb-fn instance)
+   (apply-partially #'copilot-chat--shell-cb-prompt-wrapper shell)
    (copilot-chat-shell-maker-answer-point instance) (point))
   (let ((inhibit-read-only t))
     (with-current-buffer (copilot-chat-shell-maker-tmp-buf instance)
       (erase-buffer)))
-  (copilot-chat--ask instance command (copilot-chat-shell-cb-fn instance)))
+  (copilot-chat--ask
+   instance command (copilot-chat-shell-cb-fn instance)))
 
 (defun copilot-chat--shell (instance)
   "Start a Copilot Chat shell for INSTANCE."
-  (let ((buf (shell-maker-start
-              (make-shell-maker-config
-               :name (format "Copilot-Chat%s" (copilot-chat-directory instance))
-               :execute-command (lambda (command shell)
-                                  (copilot-chat--shell-cb instance command shell)))
-              t nil t
-              (copilot-chat--get-buffer-name (copilot-chat-directory instance)))))
+  (let ((buf
+         (shell-maker-start
+          (make-shell-maker-config
+           :name
+           (format "Copilot-Chat%s" (copilot-chat-directory instance))
+           :execute-command
+           (lambda
+             (command shell)
+             (copilot-chat--shell-cb instance command shell)))
+          t nil t
+          (copilot-chat--get-buffer-name
+           (copilot-chat-directory instance)))))
     (with-current-buffer buf
-      (setq-local default-directory (copilot-chat-directory instance)))
+      (setq-local default-directory
+                  (copilot-chat-directory instance)))
     buf))
 
-(defun copilot-chat--shell-maker-insert-prompt(instance prompt)
+(defun copilot-chat--shell-maker-insert-prompt (instance prompt)
   "Insert PROMPT in the chat buffer corresponding to INSTANCE."
   (with-current-buffer (copilot-chat--shell-maker-get-buffer instance)
     (goto-char (point-max))
     (insert prompt)))
 
-(defun copilot-chat--shell-maker-clean()
+(defun copilot-chat--shell-maker-clean ()
   "Clean the copilot chat `shell-maker' frontend."
-  (advice-remove 'copilot-chat-prompt-send #'copilot-chat--shell-maker-prompt-send))
+  (advice-remove
+   'copilot-chat-prompt-send #'copilot-chat--shell-maker-prompt-send))
 
-(defun copilot-chat-shell-maker-init()
+(defun copilot-chat-shell-maker-init ()
   "Initialize the copilot chat `shell-maker' frontend."
   (setq copilot-chat-prompt copilot-chat-markdown-prompt)
-  (advice-add 'copilot-chat-prompt-send
-              :override
-              #'copilot-chat--shell-maker-prompt-send))
+  (advice-add
+   'copilot-chat-prompt-send
+   :override #'copilot-chat--shell-maker-prompt-send))
 
 ;; Top-level execute code.
 

--- a/copilot-chat-spinner.el
+++ b/copilot-chat-spinner.el
@@ -123,8 +123,3 @@ Argument STATUS is the status message to display."
 
 (provide 'copilot-chat-spinner)
 ;;; copilot-chat-spinner.el ends here
-
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; package-lint-main-file: "copilot-chat.el"
-;; End:

--- a/copilot-chat-spinner.el
+++ b/copilot-chat-spinner.el
@@ -45,17 +45,21 @@
   "Face used for the spinner during streaming."
   :group 'copilot-chat)
 
-(defun copilot-chat--get-spinner-buffer(instance)
+(defun copilot-chat--get-spinner-buffer (instance)
   "Get Spinner buffer from the active frontend.
 Argument INSTANCE is the copilot chat instance to get the buffer for."
   (condition-case err
-      (let ((get-buffer-fn (copilot-chat-frontend-get-spinner-buffer-fn
-                            (copilot-chat--get-frontend))))
+      (let ((get-buffer-fn
+             (copilot-chat-frontend-get-spinner-buffer-fn
+              (copilot-chat--get-frontend))))
         (when (and get-buffer-fn
-                   (buffer-live-p (copilot-chat-chat-buffer instance)))
+                   (buffer-live-p
+                    (copilot-chat-chat-buffer instance)))
           (funcall get-buffer-fn instance)))
     (error
-     (when copilot-chat-debug (message "Error getting spinner buffer: %S" err)) nil)))
+     (when copilot-chat-debug
+       (message "Error getting spinner buffer: %S" err))
+     nil)))
 
 (defun copilot-chat--spinner-start (instance)
   "Start the spinner animation in the Copilot Chat buffer.
@@ -63,35 +67,40 @@ Argument INSTANCE is the copilot chat instance to use."
   (when (copilot-chat-spinner-timer instance)
     (cancel-timer (copilot-chat-spinner-timer instance)))
 
-  (setf (copilot-chat-spinner-index instance) 0
-        (copilot-chat-spinner-status instance) "Thinking"
-        (copilot-chat-spinner-timer instance) (run-with-timer
-                                               0
-                                               copilot-chat-spinner-interval
-                                               #'copilot-chat--spinner-update
-                                               instance)))
+  (setf
+   (copilot-chat-spinner-index instance) 0
+   (copilot-chat-spinner-status instance) "Thinking"
+   (copilot-chat-spinner-timer instance)
+   (run-with-timer
+    0 copilot-chat-spinner-interval #'copilot-chat--spinner-update
+    instance)))
 
 (defun copilot-chat--spinner-update (instance)
   "Update the spinner animation in the Copilot Chat buffer.
 Argument INSTANCE is the copilot chat instance to use."
   (let ((buffer (copilot-chat--get-spinner-buffer instance)))
     (when (and buffer (buffer-live-p buffer))
-      (let ((frame (nth (copilot-chat-spinner-index instance)
-                        copilot-chat-spinner-frames))
-            (status-text (if (copilot-chat-spinner-status instance)
-                             (concat (copilot-chat-spinner-status instance) " ")
-                           "")))
+      (let ((frame
+             (nth
+              (copilot-chat-spinner-index instance)
+              copilot-chat-spinner-frames))
+            (status-text
+             (if (copilot-chat-spinner-status instance)
+                 (concat (copilot-chat-spinner-status instance) " ")
+               "")))
         (with-current-buffer buffer
           (save-excursion
             ;; Remove existing spinner overlay if any
-            (remove-overlays (point-min) (point-max) 'copilot-chat-spinner t)
+            (remove-overlays
+             (point-min) (point-max) 'copilot-chat-spinner t)
             ;; Create new spinner overlay at the end of buffer
             (goto-char (point-max))
             (let ((ov (make-overlay (point) (point))))
               (overlay-put ov 'copilot-chat-spinner t)
-              (overlay-put ov 'after-string
-                           (propertize (concat status-text frame)
-                                       'face 'copilot-chat-spinner-face))))))
+              (overlay-put
+               ov 'after-string
+               (propertize (concat status-text frame)
+                           'face 'copilot-chat-spinner-face))))))
 
       ;; Update spinner index
       (setf (copilot-chat-spinner-index instance)
@@ -110,8 +119,11 @@ Argument INSTANCE is the copilot chat instance to use."
       (let ((buffer (copilot-chat--get-spinner-buffer instance)))
         (when (and buffer (buffer-live-p buffer))
           (with-current-buffer buffer
-            (remove-overlays (point-min) (point-max) 'copilot-chat-spinner t))))
-    (error (when copilot-chat-debug (message "Error stopping spinner: %S" err)))))
+            (remove-overlays
+             (point-min) (point-max) 'copilot-chat-spinner t))))
+    (error
+     (when copilot-chat-debug
+       (message "Error stopping spinner: %S" err)))))
 
 (defun copilot-chat--spinner-set-status (instance status)
   "Set the status message to display with the spinner.

--- a/copilot-chat-transient.el
+++ b/copilot-chat-transient.el
@@ -88,8 +88,3 @@
 
 (provide 'copilot-chat-transient)
 ;;; copilot-chat-transient.el ends here
-
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; package-lint-main-file: "copilot-chat.el"
-;; End:

--- a/copilot-chat-transient.el
+++ b/copilot-chat-transient.el
@@ -32,59 +32,64 @@
 (require 'copilot-chat-command)
 
 ;;;###autoload (autoload 'copilot-chat-transient "copilot-chat" nil t)
-(transient-define-prefix copilot-chat-transient ()
-  "Copilot chat command menu."
-  [["Commands"
-    ("d" "Display chat" copilot-chat-display)
-    ("h" "Hide chat" copilot-chat-hide)
-    ("r" "Reset & reopen" (lambda ()
-                            (interactive)
-                            (copilot-chat-reset)
-                            (copilot-chat-display)))
-    ("x" "Reset" copilot-chat-reset)
-    ("g" "Go to buffer" copilot-chat-switch-to-buffer)
-    ("M" "Set model" copilot-chat-set-model)
-    ("q" "Quit" transient-quit-one)]
-   ["Actions"
-    ("p" "Custom prompt" copilot-chat-custom-prompt-selection)
-    ("i" "Ask and insert" copilot-chat-ask-and-insert)
-    ("m" "Insert commit message" copilot-chat-insert-commit-message)]
-   ["Data"
-    ("y" "Yank last code block" copilot-chat-yank)
-    ("s" "Send code to buffer" copilot-chat-send-to-buffer)]
-   ["Tools"
-    ("b" "Buffers" copilot-chat-transient-buffers)
-    ("c" "Code helpers" copilot-chat-transient-code)]
-   ])
+(transient-define-prefix
+ copilot-chat-transient () "Copilot chat command menu."
+ [["Commands"
+   ("d" "Display chat" copilot-chat-display)
+   ("h" "Hide chat" copilot-chat-hide)
+   ("r" "Reset & reopen"
+    (lambda ()
+      (interactive)
+      (copilot-chat-reset)
+      (copilot-chat-display)))
+   ("x" "Reset" copilot-chat-reset)
+   ("g" "Go to buffer" copilot-chat-switch-to-buffer)
+   ("M" "Set model" copilot-chat-set-model)
+   ("q" "Quit" transient-quit-one)]
+  ["Actions"
+   ("p" "Custom prompt" copilot-chat-custom-prompt-selection)
+   ("i" "Ask and insert" copilot-chat-ask-and-insert)
+   ("m" "Insert commit message" copilot-chat-insert-commit-message)]
+  ["Data"
+   ("y" "Yank last code block" copilot-chat-yank)
+   ("s" "Send code to buffer" copilot-chat-send-to-buffer)]
+  ["Tools"
+   ("b" "Buffers" copilot-chat-transient-buffers)
+   ("c" "Code helpers" copilot-chat-transient-code)]])
 
 ;;;###autoload (autoload 'copilot-chat-transient-buffers "copilot-chat" nil t)
-(transient-define-prefix copilot-chat-transient-buffers ()
-  "Copilot chat buffers menu."
-  [["Buffers"
-    ("a" "Add buffers" copilot-chat-add-buffers)
-    ("A" "Add all buffers in current frame" copilot-chat-add-buffers-in-current-window)
-    ("d" "Delete buffers" copilot-chat-del-buffers)
-    ("D" "Delete all buffers" copilot-chat-list-clear-buffers)
-    ("f" "Add files under current directory" copilot-chat-add-files-under-dir)
-    ("l" "Display buffer list" copilot-chat-list)
-    ("c" "Clear buffers" copilot-chat-list-clear-buffers)
-    ("q" "Quit" transient-quit-one)]])
+(transient-define-prefix
+ copilot-chat-transient-buffers () "Copilot chat buffers menu."
+ [["Buffers" ("a" "Add buffers" copilot-chat-add-buffers)
+   ("A"
+    "Add all buffers in current frame"
+    copilot-chat-add-buffers-in-current-window)
+   ("d" "Delete buffers" copilot-chat-del-buffers)
+   ("D" "Delete all buffers" copilot-chat-list-clear-buffers)
+   ("f"
+    "Add files under current directory"
+    copilot-chat-add-files-under-dir)
+   ("l" "Display buffer list" copilot-chat-list)
+   ("c"
+    "Clear buffers"
+    copilot-chat-list-clear-buffers)
+   ("q" "Quit" transient-quit-one)]])
 
 ;;;###autoload (autoload 'copilot-chat-transient-code "copilot-chat" nil t)
-(transient-define-prefix copilot-chat-transient-code ()
-  "Copilot chat code helpers menu."
-  [["Code helpers"
-    ("e" "Explain" copilot-chat-explain)
-    ("E" "Explain symbol" copilot-chat-explain-symbol-at-line)
-    ("r" "Review" copilot-chat-review)
-    ("d" "Doc" copilot-chat-doc)
-    ("f" "Fix" copilot-chat-fix)
-    ("o" "Optimize" copilot-chat-optimize)
-    ("t" "Test" copilot-chat-test)
-    ("F" "Explain function" copilot-chat-explain-defun)
-    ("c" "Custom prompt function" copilot-chat-custom-prompt-function)
-    ("R" "Review whole buffer" copilot-chat-review-whole-buffer)
-    ("q" "Quit" transient-quit-one)]])
+(transient-define-prefix
+ copilot-chat-transient-code () "Copilot chat code helpers menu."
+ [["Code helpers"
+   ("e" "Explain" copilot-chat-explain)
+   ("E" "Explain symbol" copilot-chat-explain-symbol-at-line)
+   ("r" "Review" copilot-chat-review)
+   ("d" "Doc" copilot-chat-doc)
+   ("f" "Fix" copilot-chat-fix)
+   ("o" "Optimize" copilot-chat-optimize)
+   ("t" "Test" copilot-chat-test)
+   ("F" "Explain function" copilot-chat-explain-defun)
+   ("c" "Custom prompt function" copilot-chat-custom-prompt-function)
+   ("R" "Review whole buffer" copilot-chat-review-whole-buffer)
+   ("q" "Quit" transient-quit-one)]])
 
 (provide 'copilot-chat-transient)
 ;;; copilot-chat-transient.el ends here

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -55,15 +55,18 @@
 
 (defcustom copilot-chat-frontend 'org
   "Frontend to use with `copilot-chat'.  Can be org or markdown."
-  :type '(choice (const :tag "org-mode" org)
-                 (const :tag "markdown" markdown)
-                 (const :tag "shell-maker" shell-maker))
-  :set (lambda (symbol value)
-         (set-default-toplevel-value symbol value)
-         (pcase value
-           (`org (require 'copilot-chat-org))
-           (`markdown (require 'copilot-chat-markdown))
-           (`shell-maker (require 'copilot-chat-shell-maker))))
+  :type
+  '(choice
+    (const :tag "org-mode" org)
+    (const :tag "markdown" markdown)
+    (const :tag "shell-maker" shell-maker))
+  :set
+  (lambda (symbol value)
+    (set-default-toplevel-value symbol value)
+    (pcase value
+      (`org (require 'copilot-chat-org))
+      (`markdown (require 'copilot-chat-markdown))
+      (`shell-maker (require 'copilot-chat-shell-maker))))
   :group 'copilot-chat)
 
 (provide 'copilot-chat)

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -68,7 +68,3 @@
 
 (provide 'copilot-chat)
 ;;; copilot-chat.el ends here
-
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; End:


### PR DESCRIPTION
I have introduced a powerful code formatter, [elisp-autofmt](https://codeberg.org/ideasman42/emacs-elisp-autofmt/).
This code formatter has an opinionated approach comparable to prettier.
For collaborative work with multiple people,
I determined that such a prescriptive approach would prevent conflicts over trivial style differences.
I personally feel some resistance to this strict automatic formatting approach.
However, from my experience with prettier and fourmolu,
I've learned that you eventually adapt,
and it becomes easier as you no longer need to worry about minor code style details.
