### PR TITLE
ci: restrict workflow to run only on master branch for push events

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,6 +2,8 @@ name: check
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
Do not run on double action on PR.
