### PR TITLE
feat(chat): add support for image handling with gpt-4o model

### DIFF
--- a/copilot-chat-body.el
+++ b/copilot-chat-body.el
@@ -99,6 +99,47 @@ INSTANCE is the `copilot-chat' instance being used."
         (funcall format-buffer-fn buffer instance)
       (buffer-substring-no-properties (point-min) (point-max)))))
 
+(defun copilot-chat--image-to-base64 (file)
+  "Convert an image FILE to a base64 encoded string."
+  (with-temp-buffer
+    (insert-file-contents-literally file)
+    (base64-encode-region (point-min) (point-max) t)
+    (buffer-string)))
+
+(defun copilot-chat--add-buffer-to-req (buffer instance messages)
+  "Add BUFFER content to messages.
+INSTANCE is the `copilot-chat' instance being used."
+  (when (buffer-live-p buffer)
+    (let ((filename (buffer-file-name buffer)))
+      (if (and filename
+               (copilot-chat--model-is-gpt-4o instance)
+               (image-supported-file-p filename))
+          (push (list
+                 `(content
+                   .
+                   ,(vconcat
+                     (list
+                      (list
+                       `(type . "text") `(text . ,(concat "FILE " filename)))
+                      (list
+                       `(type . , "image_url")
+                       `(image_url
+                         .
+                         ,(list
+                           `(url
+                             .
+                             ,(concat
+                               "data:image/jpeg;base64,"
+                               (copilot-chat--image-to-base64 filename)))))))))
+                 `(role . "user"))
+                messages)
+        (push (list
+               `(content
+                 . ,(copilot-chat--format-buffer-for-copilot buffer instance))
+               `(role . "user"))
+              messages))))
+  messages)
+
 (defun copilot-chat--create-req (instance prompt no-context)
   "Create a request for Copilot.
 Argument INSTANCE is the copilot chat instance to use.
@@ -133,12 +174,8 @@ The create req function is called first and will return new prompt."
       (setf (copilot-chat-buffers instance)
             (cl-remove-if-not #'buffer-live-p (copilot-chat-buffers instance)))
       (dolist (buffer (copilot-chat-buffers instance))
-        (when (buffer-live-p buffer)
-          (push (list
-                 `(content
-                   . ,(copilot-chat--format-buffer-for-copilot buffer instance))
-                 `(role . "user"))
-                messages))))
+        (setq messages
+              (copilot-chat--add-buffer-to-req buffer instance messages))))
     ;; system.
     ;; Add custom instruction as a separate message if available.
     ;; Prefer Global < Project.

--- a/copilot-chat-body.el
+++ b/copilot-chat-body.el
@@ -27,6 +27,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'image)
 
 (require 'copilot-chat-frontend)
 (require 'copilot-chat-instance)
@@ -109,7 +110,7 @@ INSTANCE is the `copilot-chat' instance being used."
       (concat "data:" mime-type ";base64," (buffer-string)))))
 
 (defun copilot-chat--add-buffer-to-req (buffer instance messages)
-  "Add BUFFER content to messages.
+  "Add BUFFER content to MESSAGES.
 INSTANCE is the `copilot-chat' instance being used."
   (when (buffer-live-p buffer)
     (let ((filename (buffer-file-name buffer)))

--- a/copilot-chat-body.el
+++ b/copilot-chat-body.el
@@ -100,11 +100,13 @@ INSTANCE is the `copilot-chat' instance being used."
       (buffer-substring-no-properties (point-min) (point-max)))))
 
 (defun copilot-chat--image-to-base64 (file)
-  "Convert an image FILE to a base64 encoded string."
-  (with-temp-buffer
-    (insert-file-contents-literally file)
-    (base64-encode-region (point-min) (point-max) t)
-    (buffer-string)))
+  "Convert an image FILE to a base64 encoded string with MIME type."
+  (let ((mime-type
+         (or (mailcap-file-name-to-mime-type file) "application/octet-stream")))
+    (with-temp-buffer
+      (insert-file-contents-literally file)
+      (base64-encode-region (point-min) (point-max) t)
+      (concat "data:" mime-type ";base64," (buffer-string)))))
 
 (defun copilot-chat--add-buffer-to-req (buffer instance messages)
   "Add BUFFER content to messages.
@@ -127,10 +129,7 @@ INSTANCE is the `copilot-chat' instance being used."
                          .
                          ,(list
                            `(url
-                             .
-                             ,(concat
-                               "data:image/jpeg;base64,"
-                               (copilot-chat--image-to-base64 filename)))))))))
+                             . ,(copilot-chat--image-to-base64 filename))))))))
                  `(role . "user"))
                 messages)
         (push (list

--- a/copilot-chat-curl.el
+++ b/copilot-chat-curl.el
@@ -154,7 +154,9 @@ Optional argument ARGS are additional arguments to pass to curl."
            "-H"
            "editor-plugin-version: CopilotChat.nvim/2.0.0"
            "-H"
-           "editor-version: Neovim/0.10.0")
+           "editor-version: Neovim/0.10.0"
+           "-H"
+           "Copilot-Vision-Request: true")
           (when data
             (list "-d" data))
           (when copilot-chat-curl-proxy

--- a/copilot-chat-instance.el
+++ b/copilot-chat-instance.el
@@ -73,6 +73,10 @@ Use `copilot-chat-set-model' to interactively select a model."
   "Check if the model of INSTANCE is o1."
   (string-prefix-p "o1" (copilot-chat-model instance)))
 
+(defun copilot-chat--model-is-gpt-4o (instance)
+  "Check if the model of INSTANCE is gpt-4o."
+  (string-prefix-p "gpt-4o" (copilot-chat-model instance)))
+
 (defun copilot-chat--get-list-buffer-create (instance)
   "Get or create the Copilot chat list buffer for INSTANCE."
   (let ((list-buffer

--- a/copilot-chat-request.el
+++ b/copilot-chat-request.el
@@ -198,6 +198,7 @@ if the prompt is out of context."
        ("content-type" . "application/json")
        ("user-agent" . "CopilotChat.nvim/2.0.0")
        ("editor-plugin-version" . "CopilotChat.nvim/2.0.0")
+       ("Copilot-Vision-Request" . "true")
        ("authorization" .
         ,(concat
           "Bearer "

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -5,7 +5,7 @@
 ;; Author: cedric.chepied <cedric.chepied@gmail.com>
 ;; Version: 3.0.0
 ;; URL: https://github.com/chep/copilot-chat.el
-;; Package-Requires: ((emacs "27.1") (aio "1.0") (request "0.3.2") (transient "0.8.3") (polymode "0.2.2") (org "9.4.6") (markdown-mode "2.6") (shell-maker "0.76.2"))
+;; Package-Requires: ((emacs "29.1") (aio "1.0") (request "0.3.2") (transient "0.8.3") (polymode "0.2.2") (org "9.4.6") (markdown-mode "2.6") (shell-maker "0.76.2"))
 ;; Keywords: convenience, tools
 
 

--- a/readme.org
+++ b/readme.org
@@ -13,19 +13,8 @@ This plugin allows you to chat with GitHub copilot.
 Feel free to contribute, report issues or discuss new features.
 
 * News
-** V3
-v3.0.0 is here.
-
-In v3, you can start several chat instances.
-
-** Multiple instances
-You can now work with multiple chat instances at once. Copilot-chat instances are linked to a parent directory, with each instance having dedicated:
-- Chat history
-- Context
-- Model selection
-- Buffer list
-
-~copilot-chat-display~ (alias ~(copilot-chat)~) will try to guess the appropriate instance based on the current buffer's file location. If it fails, it will ask you to choose an instance. With a prefix argument (~C-u M-x copilot-chat-display~), it will always prompt you to select an instance.
+** Copilot-Vision
+When using =gpt-4o= model, you can now send images to Copilot. Open it in emacs and add the buffer to the context like any other one.
 
 ** Help wanted
 Bug reports and new ideas are very welcome.


### PR DESCRIPTION
Introduce functionality to send images to Copilot when using the gpt-4o model. Added a new function `copilot-chat--image-to-base64` to convert image files to base64 strings and updated the request creation logic to include image data when applicable.

BREAKING CHANGE: Requires gpt-4o model for image handling.

Fixes #121 