### PR TITLE
refactor: add fill-column variables in files

### DIFF
--- a/copilot-chat-body.el
+++ b/copilot-chat-body.el
@@ -55,17 +55,15 @@ ignore it and emit a message."
          (github-dir (locate-dominating-file starting-path ".github"))
          (instruction-file
           (and github-dir
-               (expand-file-name (concat ".github/" file-name)
-                                 github-dir))))
+               (expand-file-name (concat ".github/" file-name) github-dir))))
     (when (and instruction-file (file-readable-p instruction-file))
       ;; Skip the file if it exceeds the configured size limit.
       (when (and copilot-chat-max-instruction-size
-                 (> (file-attribute-size
-                     (file-attributes instruction-file))
+                 (> (file-attribute-size (file-attributes instruction-file))
                     copilot-chat-max-instruction-size))
-        (message
-         "[copilot-chat] `%s` is larger than %d bytes; ignored."
-         instruction-file copilot-chat-max-instruction-size)
+        (message "[copilot-chat] `%s` is larger than %d bytes; ignored."
+                 instruction-file
+                 copilot-chat-max-instruction-size)
         (cl-return-from copilot-chat--read-instruction-file nil))
       (with-temp-buffer
         (insert-file-contents instruction-file)
@@ -79,8 +77,7 @@ ignore it and emit a message."
 (defun copilot-chat--read-git-commit-instructions-file ()
   "Return the content of `.github/git-commit-instructions.md' or nil."
   (when copilot-chat-use-git-commit-instruction-files
-    (copilot-chat--read-instruction-file
-     "git-commit-instructions.md")))
+    (copilot-chat--read-instruction-file "git-commit-instructions.md")))
 
 (defun copilot-chat--format-copilot-instructions (instruction-content)
   "Format instruction content according to Copilot's expected format.
@@ -97,8 +94,7 @@ INSTRUCTION-CONTENT is the content read from the instructions file."
   "Format BUFFER content for Copilot with metadata to improve understanding.
 INSTANCE is the `copilot-chat' instance being used."
   (let ((format-buffer-fn
-         (copilot-chat-frontend-format-buffer-fn
-          (copilot-chat--get-frontend))))
+         (copilot-chat-frontend-format-buffer-fn (copilot-chat--get-frontend))))
     (if format-buffer-fn
         (funcall format-buffer-fn buffer instance)
       (buffer-substring-no-properties (point-min) (point-max)))))
@@ -110,8 +106,7 @@ Argument PROMPT Copilot prompt to send.
 Argument NO-CONTEXT tells `copilot-chat' to not send history and buffers.
 The create req function is called first and will return new prompt."
   (let* ((create-req-fn
-          (copilot-chat-frontend-create-req-fn
-           (copilot-chat--get-frontend)))
+          (copilot-chat-frontend-create-req-fn (copilot-chat--get-frontend)))
          (copilot-instruction-content
           (and copilot-chat-use-copilot-instruction-files
                (copilot-chat--read-copilot-instructions-file)))
@@ -132,20 +127,16 @@ The create req function is called first and will return new prompt."
     (unless no-context
       ;; history
       (dolist (history (copilot-chat-history instance))
-        (push (list
-               `(content . ,(car history)) `(role . ,(cadr history)))
-              messages))
+        (push
+         (list `(content . ,(car history)) `(role . ,(cadr history))) messages))
       ;; Clean buffer list once and add buffer contents
       (setf (copilot-chat-buffers instance)
-            (cl-remove-if-not
-             #'buffer-live-p (copilot-chat-buffers instance)))
+            (cl-remove-if-not #'buffer-live-p (copilot-chat-buffers instance)))
       (dolist (buffer (copilot-chat-buffers instance))
         (when (buffer-live-p buffer)
           (push (list
                  `(content
-                   .
-                   ,(copilot-chat--format-buffer-for-copilot
-                     buffer instance))
+                   . ,(copilot-chat--format-buffer-for-copilot buffer instance))
                  `(role . "user"))
                 messages))))
     ;; system.
@@ -153,20 +144,17 @@ The create req function is called first and will return new prompt."
     ;; Prefer Global < Project.
     (when formatted-copilot-instructions
       (push (list
-             `(content . ,formatted-copilot-instructions)
-             `(role . "system"))
+             `(content . ,formatted-copilot-instructions) `(role . "system"))
             messages))
 
     (when (and git-commit-instruction-content
                (eq (copilot-chat-type instance) 'commit))
       (push (list
-             `(content . ,git-commit-instruction-content)
-             `(role . "system"))
+             `(content . ,git-commit-instruction-content) `(role . "system"))
             messages))
 
     ;; Global instruction.
-    (push (list `(content . ,copilot-chat-prompt) `(role . "system"))
-          messages)
+    (push (list `(content . ,copilot-chat-prompt) `(role . "system")) messages)
 
     ;; Create the appropriate payload based on model type
     (json-serialize
@@ -184,3 +172,8 @@ The create req function is called first and will return new prompt."
 
 (provide 'copilot-chat-body)
 ;;; copilot-chat-body.el ends here
+
+;; Local Variables:
+;; byte-compile-warnings: (not obsolete)
+;; fill-column: 80
+;; End:

--- a/copilot-chat-command.el
+++ b/copilot-chat-command.el
@@ -62,10 +62,8 @@ If nil, show absolute path."
 ;; Variables
 (defvar copilot-chat-list-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key
-     map (kbd "RET") 'copilot-chat-list-add-or-remove-buffer)
-    (define-key
-     map (kbd "SPC") 'copilot-chat-list-add-or-remove-buffer)
+    (define-key map (kbd "RET") 'copilot-chat-list-add-or-remove-buffer)
+    (define-key map (kbd "SPC") 'copilot-chat-list-add-or-remove-buffer)
     (define-key map (kbd "C-c C-c") 'copilot-chat-list-clear-buffers)
     (define-key
      map (kbd "g")
@@ -100,14 +98,12 @@ to Copilot for processing."
       (let ((prompt (copilot-chat--pop-current-prompt instance)))
         (copilot-chat--write-buffer
          instance
-         (copilot-chat--format-data instance prompt 'prompt)
-         nil)
+         (copilot-chat--format-data instance prompt 'prompt) nil)
         (with-current-buffer (copilot-chat--get-buffer instance)
           (recenter-top-bottom))
         (push prompt (copilot-chat-prompt-history instance))
         (setf (copilot-chat-prompt-history-position instance) nil)
-        (copilot-chat--ask
-         instance prompt 'copilot-chat-prompt-cb)))))
+        (copilot-chat--ask instance prompt 'copilot-chat-prompt-cb)))))
 
 ;;;###autoload (autoload 'copilot-chat-ask-and-insert "copilot-chat" nil t)
 (defun copilot-chat-ask-and-insert ()
@@ -180,8 +176,7 @@ BEG and END are the beginning and end positions of the region to test."
 Argument INSTANCE is the copilot chat instance to use.
 Argument PROMPT is the text to insert in the prompt region."
   (let ((prompt-fn
-         (copilot-chat-frontend-insert-prompt-fn
-          (copilot-chat--get-frontend))))
+         (copilot-chat-frontend-insert-prompt-fn (copilot-chat--get-frontend))))
     (when prompt-fn
       (funcall prompt-fn instance prompt))))
 
@@ -207,8 +202,7 @@ Derives language name from the major mode of the current buffer."
   "Format code according to the frontend.
 Argument CODE is the code to be formatted."
   (let ((format-fn
-         (copilot-chat-frontend-format-code-fn
-          (copilot-chat--get-frontend))))
+         (copilot-chat-frontend-format-code-fn (copilot-chat--get-frontend))))
     (if format-fn
         (funcall format-fn code (copilot-chat--get-language))
       code)))
@@ -261,10 +255,8 @@ It can be used to review the magit diff for my change, or other people's"
 Side by side with the current code editing buffer."
   (interactive)
   (let ((instance (copilot-chat--current-instance)))
-    (unless (equal
-             (pm-base-buffer) (copilot-chat--get-buffer instance))
-      (switch-to-buffer-other-window
-       (copilot-chat--get-buffer instance))))
+    (unless (equal (pm-base-buffer) (copilot-chat--get-buffer instance))
+      (switch-to-buffer-other-window (copilot-chat--get-buffer instance))))
   (copilot-chat-goto-input))
 
 ;;;###autoload (autoload 'copilot-chat-custom-prompt-selection "copilot-chat" nil t)
@@ -273,13 +265,10 @@ Side by side with the current code editing buffer."
 If CUSTOM-PROMPT is provided, use it instead of reading from the mini-buffer."
   (interactive)
   (let* ((instance (copilot-chat--current-instance))
-         (prompt
-          (or custom-prompt
-              (read-from-minibuffer "Copilot prompt: ")))
+         (prompt (or custom-prompt (read-from-minibuffer "Copilot prompt: ")))
          (code
           (if (use-region-p)
-              (buffer-substring-no-properties
-               (region-beginning) (region-end))
+              (buffer-substring-no-properties (region-beginning) (region-end))
             (buffer-substring-no-properties (point-min) (point-max))))
          (formatted-prompt
           (concat prompt "\n" (copilot-chat--format-code code))))
@@ -291,8 +280,7 @@ If CUSTOM-PROMPT is provided, use it instead of reading from the mini-buffer."
   (interactive)
   (let* ((instance (copilot-chat--current-instance))
          (prompt "Question for copilot-chat: ")
-         (input
-          (read-string prompt nil 'copilot-chat--prompt-history)))
+         (input (read-string prompt nil 'copilot-chat--prompt-history)))
     (copilot-chat--insert-and-send-prompt instance input)))
 
 ;;;###autoload (autoload 'copilot-chat-list "copilot-chat" nil t)
@@ -310,8 +298,7 @@ If CUSTOM-PROMPT is provided, use it instead of reading from the mini-buffer."
   "Internal function to display copilot chat buffer.
 Argument INSTANCE is the copilot chat instance to display."
   (let ((base-buffer (copilot-chat--get-buffer instance))
-        (init-fn
-         (copilot-chat-frontend-init-fn (copilot-chat--get-frontend)))
+        (init-fn (copilot-chat-frontend-init-fn (copilot-chat--get-frontend)))
         (window-found nil))
     (when init-fn
       (funcall init-fn))
@@ -383,11 +370,12 @@ Optional argument ARG if non-nil, force instance selection."
   (interactive (list
                 (completing-read-multiple
                  "Buffers: "
-                 (mapcar #'buffer-name (buffer-list)) nil t
+                 (mapcar #'buffer-name (buffer-list))
+                 nil
+                 t
                  (buffer-name (current-buffer)))))
   (let ((instance (copilot-chat--current-instance)))
-    (mapc
-     (lambda (buf) (copilot-chat--add-buffer instance buf)) buffers)
+    (mapc (lambda (buf) (copilot-chat--add-buffer instance buf)) buffers)
     (copilot-chat-list-refresh instance)))
 
 (defun copilot-chat-del-buffers (buffers)
@@ -395,11 +383,12 @@ Optional argument ARG if non-nil, force instance selection."
   (interactive (list
                 (completing-read-multiple
                  "Buffers: "
-                 (mapcar #'buffer-name (buffer-list)) nil t
+                 (mapcar #'buffer-name (buffer-list))
+                 nil
+                 t
                  (buffer-name (current-buffer)))))
   (let ((instance (copilot-chat--current-instance)))
-    (mapc
-     (lambda (buf) (copilot-chat--del-buffer instance buf)) buffers)
+    (mapc (lambda (buf) (copilot-chat--del-buffer instance buf)) buffers)
     (copilot-chat-list-refresh instance)))
 
 (defun copilot-chat-add-file (file-path)
@@ -437,9 +426,10 @@ If there are more than 40 files, refuse to add and show warning message."
                              t (concat "\\." current-suffix "$")
                              t))) ; t means don't include . and ..
       (if (> (length files) max-files)
-          (message
-           "Too many files (%d, > %d) found with suffix .%s. Aborting."
-           (length files) max-files current-suffix)
+          (message "Too many files (%d, > %d) found with suffix .%s. Aborting."
+                   (length files)
+                   max-files
+                   current-suffix)
         (dolist (file files)
           (copilot-chat-add-file file))
         (message "Added %d files with suffix .%s"
@@ -456,10 +446,7 @@ If there are more than 40 files, refuse to add and show warning message."
                (and buffer-file-name
                     (file-in-directory-p buffer-file-name dir))))
            (buffer-list))))
-    (cl-union
-     bufs-under-dir
-     (copilot-chat-buffers instance)
-     :test #'eq)))
+    (cl-union bufs-under-dir (copilot-chat-buffers instance) :test #'eq)))
 
 (defun copilot-chat-list-refresh (&optional instance)
   "Refresh the list of buffers in the current Copilot chat list buffer.
@@ -468,8 +455,7 @@ Optional argument INSTANCE specifies which instance to refresh the list for."
   (unless instance
     (setq instance (copilot-chat--current-instance)))
   (setf (copilot-chat-buffers instance)
-        (cl-remove-if-not
-         #'buffer-live-p (copilot-chat-buffers instance)))
+        (cl-remove-if-not #'buffer-live-p (copilot-chat-buffers instance)))
   (with-current-buffer (copilot-chat--get-list-buffer-create instance)
     (let* ((pt (point))
            (inhibit-read-only t)
@@ -482,20 +468,17 @@ Optional argument INSTANCE specifies which instance to refresh the list for."
                   (lambda (a b)
                     (string<
                      (symbol-name (buffer-local-value 'major-mode a))
-                     (symbol-name
-                      (buffer-local-value 'major-mode b)))))))
+                     (symbol-name (buffer-local-value 'major-mode b)))))))
       (erase-buffer)
       (setq-local header-line-format
-                  (concat
-                   "Copilot chat " (copilot-chat-directory instance)))
+                  (concat "Copilot chat " (copilot-chat-directory instance)))
       (dolist (buffer sorted-buffers)
         (let* ((file-name (buffer-file-name buffer))
                (buffer-name
                 (if (and file-name copilot-chat-list-show-path)
                     (if copilot-chat-list-show-relative-path
                         (file-relative-name file-name
-                                            (copilot-chat-directory
-                                             instance))
+                                            (copilot-chat-directory instance))
                       file-name)
                   (buffer-name buffer)))
                (cop-bufs (copilot-chat--get-buffers instance)))
@@ -516,16 +499,13 @@ Optional argument INSTANCE specifies which instance to refresh the list for."
   (interactive)
   (let* ((instance (copilot-chat--current-instance))
          (buffer-name
-          (buffer-substring
-           (line-beginning-position) (line-end-position)))
+          (buffer-substring (line-beginning-position) (line-end-position)))
          (buffer
           (if copilot-chat-list-show-path
               (or (get-file-buffer
                    (if copilot-chat-list-show-relative-path
                        (concat
-                        (copilot-chat-directory instance)
-                        "/"
-                        buffer-name)
+                        (copilot-chat-directory instance) "/" buffer-name)
                      buffer-name))
                   (get-buffer buffer-name))
             (get-buffer buffer-name)))
@@ -534,11 +514,9 @@ Optional argument INSTANCE specifies which instance to refresh the list for."
       (if (member buffer cop-bufs)
           (progn
             (copilot-chat--del-buffer instance buffer)
-            (message "Buffer '%s' removed from Copilot chat list."
-                     buffer-name))
+            (message "Buffer '%s' removed from Copilot chat list." buffer-name))
         (copilot-chat--add-buffer instance buffer)
-        (message "Buffer '%s' added to Copilot chat list."
-                 buffer-name)))
+        (message "Buffer '%s' added to Copilot chat list." buffer-name)))
     (copilot-chat-list-refresh instance)))
 
 (defun copilot-chat-list-clear-buffers ()
@@ -568,17 +546,13 @@ Optional argument INSTANCE specifies which instance to refresh the list for."
               nil
             (if (null (copilot-chat-prompt-history-position instance))
                 (progn
-                  (setf (copilot-chat-prompt-history-position
-                         instance)
-                        0)
+                  (setf (copilot-chat-prompt-history-position instance) 0)
                   (car (copilot-chat-prompt-history instance)))
               (if (= (copilot-chat-prompt-history-position instance)
-                     (1- (length
-                          (copilot-chat-prompt-history instance))))
+                     (1- (length (copilot-chat-prompt-history instance))))
                   (car (last (copilot-chat-prompt-history instance)))
                 (setf (copilot-chat-prompt-history-position instance)
-                      (1+ (copilot-chat-prompt-history-position
-                           instance)))
+                      (1+ (copilot-chat-prompt-history-position instance)))
                 (nth
                  (copilot-chat-prompt-history-position instance)
                  (copilot-chat-prompt-history instance)))))))
@@ -595,14 +569,11 @@ Optional argument INSTANCE specifies which instance to refresh the list for."
               nil
             (if (null (copilot-chat-prompt-history-position instance))
                 nil
-              (if (= 0
-                     (copilot-chat-prompt-history-position instance))
+              (if (= 0 (copilot-chat-prompt-history-position instance))
                   ""
                 (progn
-                  (setf (copilot-chat-prompt-history-position
-                         instance)
-                        (1- (copilot-chat-prompt-history-position
-                             instance)))
+                  (setf (copilot-chat-prompt-history-position instance)
+                        (1- (copilot-chat-prompt-history-position instance)))
                   (nth
                    (copilot-chat-prompt-history-position instance)
                    (copilot-chat-prompt-history instance))))))))
@@ -639,8 +610,7 @@ Optional argument KEEP-BUFFERS if non-nil, preserve the current buffer list."
 (defun copilot-chat--clean ()
   "Cleaning function."
   (let ((clean-fn
-         (copilot-chat-frontend-clean-fn
-          (copilot-chat--get-frontend))))
+         (copilot-chat-frontend-clean-fn (copilot-chat--get-frontend))))
     (when clean-fn
       (funcall clean-fn))))
 
@@ -658,9 +628,7 @@ Replace selection if any."
 (defun copilot-chat-copy-code-at-point ()
   "Copy the code block at point into kill ring."
   (interactive)
-  (let ((copy-fn
-         (copilot-chat-frontend-copy-fn
-          (copilot-chat--get-frontend))))
+  (let ((copy-fn (copilot-chat-frontend-copy-fn (copilot-chat--get-frontend))))
     (when copy-fn
       (funcall copy-fn))))
 
@@ -697,12 +665,10 @@ wait for the fetch to complete."
          (seq-filter
           #'copilot-chat--model-enabled-p
           (if copilot-chat-model-ignore-picker
-              (copilot-chat-connection-models
-               copilot-chat--connection)
+              (copilot-chat-connection-models copilot-chat--connection)
             (seq-filter
              #'copilot-chat--model-picker-enabled
-             (copilot-chat-connection-models
-              copilot-chat--connection))))))
+             (copilot-chat-connection-models copilot-chat--connection))))))
     (if models
         (let* ((model-info-list
                 (mapcar
@@ -710,33 +676,27 @@ wait for the fetch to complete."
                    (let* ((id (alist-get 'id model))
                           (name (alist-get 'name model))
                           (clean-name
-                           (replace-regexp-in-string
-                            " (Preview)$" "" name))
+                           (replace-regexp-in-string " (Preview)$" "" name))
                           (vendor (alist-get 'vendor model))
-                          (capabilities
-                           (alist-get 'capabilities model))
+                          (capabilities (alist-get 'capabilities model))
                           (limits (alist-get 'limits capabilities))
-                          (preview-p
-                           (eq t (alist-get 'preview model)))
+                          (preview-p (eq t (alist-get 'preview model)))
                           (preview-text
                            (if preview-p
                                " (Preview)"
                              ""))
-                          (prompt-tokens
-                           (alist-get 'max_prompt_tokens limits))
+                          (prompt-tokens (alist-get 'max_prompt_tokens limits))
                           (output-tokens
                            (or (alist-get 'max_output_tokens limits)
                                (when (string-prefix-p "o1" id)
                                  100000)))
                           (prompt-text
                            (if prompt-tokens
-                               (format "%dk"
-                                       (round (/ prompt-tokens 1000)))
+                               (format "%dk" (round (/ prompt-tokens 1000)))
                              "?"))
                           (output-text
                            (if output-tokens
-                               (format "%dk"
-                                       (round (/ output-tokens 1000)))
+                               (format "%dk" (round (/ output-tokens 1000)))
                              "?")))
                      (list
                       :id id
@@ -777,13 +737,12 @@ wait for the fetch to complete."
                           (length (plist-get info :output-text)))
                         model-info-list)))
                (format-str
-                (format
-                 "[%%-%ds] %%-%ds%%-%ds (Tokens in/out: %%%ds/%%%ds)"
-                 max-vendor-width
-                 max-name-width
-                 max-preview-width
-                 max-prompt-width
-                 max-output-width)))
+                (format "[%%-%ds] %%-%ds%%-%ds (Tokens in/out: %%%ds/%%%ds)"
+                        max-vendor-width
+                        max-name-width
+                        max-preview-width
+                        max-prompt-width
+                        max-output-width)))
           ;; Return list of (name . id) pairs from fetched models, sorted by ID
           (sort (mapcar
                  (lambda (info)
@@ -803,8 +762,7 @@ wait for the fetch to complete."
         (let ((cached-models (copilot-chat--load-models-from-cache)))
           (if cached-models
               (progn
-                (setf (copilot-chat-connection-models
-                       copilot-chat--connection)
+                (setf (copilot-chat-connection-models copilot-chat--connection)
                       cached-models)
                 (copilot-chat--get-model-choices-with-wait))
             ;; No cache - need to fetch
@@ -813,9 +771,8 @@ wait for the fetch to complete."
             (let ((inhibit-quit t)) ; Prevent C-g during fetch
               (copilot-chat--request-models t)
               ;; Wait for models to be fetched (with timeout)
-              (with-timeout
-                  (10
-                   (error "Timeout waiting for models to be fetched"))
+              (with-timeout (10 (error
+                                 "Timeout waiting for models to be fetched"))
                 (while (not
                         (copilot-chat-connection-models
                          copilot-chat--connection))
@@ -830,25 +787,19 @@ Fetches available models from the API if not already fetched."
    (let*
        ((choices (copilot-chat--get-model-choices-with-wait))
         (max-id-width
-         (apply #'max
-                (mapcar
-                 (lambda (choics) (length (cdr choics))) choices)))
+         (apply #'max (mapcar (lambda (choics) (length (cdr choics))) choices)))
         ;; Create completion list with ID as prefix for unique identification
         (completion-choices
          (mapcar
           (lambda (choice)
             (let ((name (car choice))
                   (id (cdr choice)))
-              (cons
-               (format (format "[%%-%ds] %%s" max-id-width)
-                       id name)
-               id)))
+              (cons (format (format "[%%-%ds] %%s" max-id-width) id name) id)))
           choices))
         (choice
-         (completing-read "Select Copilot Chat model: "
-                          (mapcar 'car completion-choices)
-                          nil
-                          t)))
+         (completing-read
+          "Select Copilot Chat model: " (mapcar 'car completion-choices)
+          nil t)))
      ;; Extract model ID from the selected choice
      (let ((model-value (cdr (assoc choice completion-choices))))
        (when copilot-chat-debug
@@ -858,8 +809,7 @@ Fetches available models from the API if not already fetched."
   ;; Set the model value only for current instance
   (let ((instance (copilot-chat--current-instance)))
     (setf (copilot-chat-model instance) model)
-    (message "Copilot Chat model set to %s for current instance"
-             model)))
+    (message "Copilot Chat model set to %s for current instance" model)))
 
 (defun copilot-chat-yank ()
   "Insert last code block given by `copilot-chat'."
@@ -891,8 +841,7 @@ INC is the number to use as increment for index in block ring."
   "Insert at point the code block at the current index in the block ring.
 Argument INSTANCE is the copilot chat instance to use."
   (when-let* ((yank-fn
-               (copilot-chat-frontend-yank-fn
-                (copilot-chat--get-frontend))))
+               (copilot-chat-frontend-yank-fn (copilot-chat--get-frontend))))
     (funcall yank-fn instance)))
 
 ;;;###autoload (autoload 'copilot-chat-clear-auth-cache "copilot-chat" nil t)
@@ -902,8 +851,7 @@ Argument INSTANCE is the copilot chat instance to use."
   (copilot-chat-reset)
   ;; remove copilot-chat-token-cache file
   (let ((token-cache-file (expand-file-name copilot-chat-token-cache))
-        (github-token-file
-         (expand-file-name copilot-chat-github-token-file)))
+        (github-token-file (expand-file-name copilot-chat-github-token-file)))
     (when (file-exists-p token-cache-file)
       (delete-file token-cache-file))
     (when (file-exists-p github-token-file)
@@ -924,8 +872,7 @@ Clears model cache from memory and disk, then triggers background fetch."
         0)
 
   ;; Remove cached models file if it exists
-  (let ((models-cache-file
-         (expand-file-name copilot-chat-models-cache-file)))
+  (let ((models-cache-file (expand-file-name copilot-chat-models-cache-file)))
     (when (file-exists-p models-cache-file)
       (delete-file models-cache-file)
       (when copilot-chat-debug
@@ -974,8 +921,7 @@ instance directory will be added."
   (interactive)
   (let ((instance (copilot-chat--current-instance)))
     (aio-with-async
-     (aio-await
-      (copilot-chat--add-workspace instance t))
+     (aio-await (copilot-chat--add-workspace instance t))
      (copilot-chat-list-refresh instance))))
 
 (defun copilot-chat-add-workspace ()
@@ -987,9 +933,13 @@ displaying a file in the instance directory will be added."
   (interactive)
   (let ((instance (copilot-chat--current-instance)))
     (aio-with-async
-     (aio-await
-      (copilot-chat--add-workspace instance nil))
+     (aio-await (copilot-chat--add-workspace instance nil))
      (copilot-chat-list-refresh instance))))
 
 (provide 'copilot-chat-command)
 ;;; copilot-chat-command.el ends here
+
+;; Local Variables:
+;; byte-compile-warnings: (not obsolete)
+;; fill-column: 80
+;; End:

--- a/copilot-chat-common.el
+++ b/copilot-chat-common.el
@@ -44,8 +44,7 @@
   :type 'boolean
   :group 'copilot-chat)
 
-(defcustom copilot-chat-github-token-file
-  "~/.config/copilot-chat/github-token"
+(defcustom copilot-chat-github-token-file "~/.config/copilot-chat/github-token"
   "The file where to find GitHub token."
   :type 'string
   :group 'copilot-chat)
@@ -83,3 +82,8 @@
 
 (provide 'copilot-chat-common)
 ;;; copilot-chat-common.el ends here
+
+;; Local Variables:
+;; byte-compile-warnings: (not obsolete)
+;; fill-column: 80
+;; End:

--- a/copilot-chat-connection.el
+++ b/copilot-chat-connection.el
@@ -47,3 +47,8 @@
 
 (provide 'copilot-chat-connection)
 ;;; copilot-chat-connection.el ends here
+
+;; Local Variables:
+;; byte-compile-warnings: (not obsolete)
+;; fill-column: 80
+;; End:

--- a/copilot-chat-copilot.el
+++ b/copilot-chat-copilot.el
@@ -36,8 +36,7 @@
   :type 'string
   :group 'copilot-chat)
 
-(defcustom copilot-chat-prompt-review
-  "Please review the following code.\n"
+(defcustom copilot-chat-prompt-review "Please review the following code.\n"
   "The prompt used by `copilot-chat-review'."
   :type 'string
   :group 'copilot-chat)
@@ -79,8 +78,7 @@
 
 (defun copilot-chat--get-cached-token ()
   "Get the cached GitHub token."
-  (let ((token-file
-         (expand-file-name copilot-chat-github-token-file)))
+  (let ((token-file (expand-file-name copilot-chat-github-token-file)))
     (when (file-exists-p token-file)
       (with-temp-buffer
         (insert-file-contents token-file)
@@ -130,13 +128,10 @@
 
     (if (< (- current-time last-fetch-time) cooldown-period)
         (when copilot-chat-debug
-          (message
-           "Skipping model fetch - in cooldown period (%d seconds left)"
-           (- cooldown-period (- current-time last-fetch-time))))
+          (message "Skipping model fetch - in cooldown period (%d seconds left)"
+                   (- cooldown-period (- current-time last-fetch-time))))
 
-      (if (not
-           (copilot-chat-connection-github-token
-            copilot-chat--connection))
+      (if (not (copilot-chat-connection-github-token copilot-chat--connection))
           (run-with-timer 5 nil #'copilot-chat--fetch-models-async)
         (setf (copilot-chat-connection-last-models-fetch-time
                copilot-chat--connection)
@@ -180,40 +175,32 @@
   "Authenticate with GitHub Copilot API.
 We first need github authorization (github token).
 Then we need a session token."
-  (unless (copilot-chat-connection-github-token
-           copilot-chat--connection)
+  (unless (copilot-chat-connection-github-token copilot-chat--connection)
     (let ((token (copilot-chat--get-cached-token)))
       (if token
-          (setf (copilot-chat-connection-github-token
-                 copilot-chat--connection)
+          (setf (copilot-chat-connection-github-token copilot-chat--connection)
                 token)
         (copilot-chat--login))))
 
-  (when (null
-         (copilot-chat-connection-token copilot-chat--connection))
+  (when (null (copilot-chat-connection-token copilot-chat--connection))
     ;; try to load token from ~/.cache/copilot-chat-token
     (let ((token-file (expand-file-name copilot-chat-token-cache)))
       (when (file-exists-p token-file)
         (with-temp-buffer
           (insert-file-contents token-file)
-          (setf (copilot-chat-connection-token
-                 copilot-chat--connection)
+          (setf (copilot-chat-connection-token copilot-chat--connection)
                 (json-read-from-string
-                 (buffer-substring-no-properties
-                  (point-min) (point-max))))))))
+                 (buffer-substring-no-properties (point-min) (point-max))))))))
 
-  (when (or (null
-             (copilot-chat-connection-token copilot-chat--connection))
+  (when (or (null (copilot-chat-connection-token copilot-chat--connection))
             (> (round (float-time (current-time)))
                (alist-get
                 'expires_at
-                (copilot-chat-connection-token
-                 copilot-chat--connection))))
+                (copilot-chat-connection-token copilot-chat--connection))))
     (copilot-chat--renew-token))
   (setf (copilot-chat-connection-ready copilot-chat--connection) t))
 
-(defun copilot-chat--ask
-    (instance prompt callback &optional out-of-context)
+(defun copilot-chat--ask (instance prompt callback &optional out-of-context)
   "Ask a question to Copilot.
 Argument INSTANCE is the copilot chat instance to use.
 Argument PROMPT is the prompt to send to copilot.
@@ -224,11 +211,9 @@ Argument OUT-OF-CONTEXT indicates if prompt is out of context (git commit)."
     (copilot-chat--auth)
     (cond
      ((eq copilot-chat-backend 'curl)
-      (copilot-chat--curl-ask
-       instance prompt callback out-of-context))
+      (copilot-chat--curl-ask instance prompt callback out-of-context))
      ((eq copilot-chat-backend 'request)
-      (copilot-chat--request-ask
-       instance prompt callback out-of-context))
+      (copilot-chat--request-ask instance prompt callback out-of-context))
      (t
       (error "Unknown backend: %s" copilot-chat-backend)))
     (unless out-of-context
@@ -278,14 +263,12 @@ All its associated buffers are killed."
       (kill-buffer lst-buf))
     (when (buffer-live-p tmp-buf)
       (kill-buffer tmp-buf))
-    (setq copilot-chat--instances
-          (delete instance copilot-chat--instances))))
+    (setq copilot-chat--instances (delete instance copilot-chat--instances))))
 
 (defun copilot-chat--create-instance ()
   "Create a new copilot chat instance for a given directory."
   (let* ((current-dir
-          (file-name-directory
-           (or (buffer-file-name) default-directory)))
+          (file-name-directory (or (buffer-file-name) default-directory)))
          (directory
           (expand-file-name
            (read-directory-name "Choose a directory: " current-dir)))
@@ -313,12 +296,8 @@ Argument DIRECTORY is the path to search for matching instance."
     (let* ((choice
             (read-multiple-choice
              "Copilot Chat Instance: "
-             '((?c
-                "Create new instance"
-                "Create a new Copilot chat instance")
-               (?l
-                "Choose from list"
-                "Choose from existing instances"))))
+             '((?c "Create new instance" "Create a new Copilot chat instance")
+               (?l "Choose from list" "Choose from existing instances"))))
            (key (car choice)))
       (cond
        ((eq key ?l)
@@ -362,3 +341,8 @@ Argument DIRECTORY is the path to search for matching instance."
 
 (provide 'copilot-chat-copilot)
 ;;; copilot-chat-copilot.el ends here
+
+;; Local Variables:
+;; byte-compile-warnings: (not obsolete)
+;; fill-column: 80
+;; End:

--- a/copilot-chat-curl.el
+++ b/copilot-chat-curl.el
@@ -84,8 +84,7 @@ authentication."
   :group 'copilot-chat)
 
 ;; functions
-(defun copilot-chat--curl-call-process
-    (address method data &rest args)
+(defun copilot-chat--curl-call-process (address method data &rest args)
   "Call curl synchronously.
 Argument ADDRESS is the URL to call.
 Argument METHOD is the HTTP method to use.
@@ -127,11 +126,9 @@ Arguments ARGS are additional arguments to pass to curl."
                   nil
                   curl-args)))
       (when (/= result 0)
-        (error
-         (format "curl returned non-zero result: %d" result))))))
+        (error (format "curl returned non-zero result: %d" result))))))
 
-(defun copilot-chat--curl-make-process
-    (address method data filter &rest args)
+(defun copilot-chat--curl-make-process (address method data filter &rest args)
   "Call curl asynchronously.
 Argument ADDRESS is the URL to call.
 Argument METHOD is the HTTP method to use.
@@ -188,9 +185,7 @@ Optional argument ARGS are additional arguments to pass to curl."
          (token-dir
           (file-name-directory
            (expand-file-name copilot-chat-github-token-file))))
-    (setf (copilot-chat-connection-github-token
-           copilot-chat--connection)
-          token)
+    (setf (copilot-chat-connection-github-token copilot-chat--connection) token)
     (when (not (file-directory-p token-dir))
       (make-directory token-dir t))
     (with-temp-file copilot-chat-github-token-file
@@ -241,10 +236,8 @@ If your browser does not open automatically, browse to %s."
           ;copilot-chat-token format
           ))
         (cache-dir
-         (file-name-directory
-          (expand-file-name copilot-chat-token-cache))))
-    (setf (copilot-chat-connection-token copilot-chat--connection)
-          json-data)
+         (file-name-directory (expand-file-name copilot-chat-token-cache))))
+    (setf (copilot-chat-connection-token copilot-chat--connection) json-data)
     ;; save token in copilot-chat-token-cache file after creating
     ;; folders if needed
     (when (not (file-directory-p cache-dir))
@@ -260,8 +253,7 @@ If your browser does not open automatically, browse to %s."
      "https://api.github.com/copilot_internal/v2/token" 'get nil
      "-H"
      (format "authorization: token %s"
-             (copilot-chat-connection-github-token
-              copilot-chat--connection)))
+             (copilot-chat-connection-github-token copilot-chat--connection)))
     (copilot-chat--curl-parse-renew-token)))
 
 
@@ -300,8 +292,7 @@ Argument SEGMENT is data segment to parse."
       (error 'partial)))))
 
 
-(defun copilot-chat--curl-analyze-response
-    (instance string callback no-history)
+(defun copilot-chat--curl-analyze-response (instance string callback no-history)
   "Analyse curl response.
 Argument INSTANCE is the copilot chat instance to use.
 Argument STRING is the data returned by curl.
@@ -341,8 +332,7 @@ if the response should be added to history."
   ;;    "data: [DONE]\n\n". Thus, `callback' is called with the value of `copilot-chat--magic', and
   ;;    the two trailing empty lines are skipped.
   (when (copilot-chat-curl-current-data instance)
-    (setq string
-          (concat (copilot-chat-curl-current-data instance) string))
+    (setq string (concat (copilot-chat-curl-current-data instance) string))
     (setf (copilot-chat-curl-current-data instance) nil))
 
   (let ((segments (split-string string "\n")))
@@ -362,8 +352,7 @@ if the response should be added to history."
           (unless no-history
             (setf (copilot-chat-history instance)
                   (cons
-                   (list
-                    (copilot-chat-curl-answer instance) "assistant")
+                   (list (copilot-chat-curl-answer instance) "assistant")
                    (copilot-chat-history instance))))
           (setf (copilot-chat-curl-answer instance) nil))
 
@@ -379,12 +368,10 @@ if the response should be added to history."
                    (token (and delta (alist-get 'content delta))))
               (when (and token (not (eq token :null)))
                 (when (not (copilot-chat-curl-answer instance))
-                  (copilot-chat--spinner-set-status
-                   instance "Generating"))
+                  (copilot-chat--spinner-set-status instance "Generating"))
                 (funcall callback instance token)
                 (setf (copilot-chat-curl-answer instance)
-                      (concat
-                       (copilot-chat-curl-answer instance) token)))))
+                      (concat (copilot-chat-curl-answer instance) token)))))
 
            ;; display .error.message in the chat.
            ((alist-get 'error extracted)
@@ -399,13 +386,11 @@ if the response should be added to history."
               ;; the assistant with its own error messages...
               (setf (copilot-chat-history instance)
                     (cons
-                     (list "" "assistant")
-                     (copilot-chat-history instance)))
+                     (list "" "assistant") (copilot-chat-history instance)))
               (setf (copilot-chat-curl-answer instance) nil)))
            ;; Fallback -- nag developers about possibly unhandled payloads
            (t
-            (warn
-             "Unhandled message from copilot: %S" extracted)))))))))
+            (warn "Unhandled message from copilot: %S" extracted)))))))))
 
 (defun copilot-chat--curl-analyze-nonstream-response
     (instance proc string callback no-history)
@@ -418,13 +403,11 @@ Argument CALLBACK is the function to call with analysed data.
 Argument NO-HISTORY is a boolean to indicate
  if the response should be added to history."
   (when (copilot-chat-curl-current-data instance)
-    (setq string
-          (concat (copilot-chat-curl-current-data instance) string))
+    (setq string (concat (copilot-chat-curl-current-data instance) string))
     (setf (copilot-chat-curl-current-data instance) nil))
 
   (condition-case err
-      (let* ((extracted
-              (json-parse-string string :object-type 'alist))
+      (let* ((extracted (json-parse-string string :object-type 'alist))
              (choices (alist-get 'choices extracted))
              (message
               (and (> (length choices) 0)
@@ -439,8 +422,7 @@ Argument NO-HISTORY is a boolean to indicate
           (unless no-history
             (setf (copilot-chat-history instance)
                   (cons
-                   (list
-                    (copilot-chat-curl-answer instance) "assistant")
+                   (list (copilot-chat-curl-answer instance) "assistant")
                    (copilot-chat-history instance))))
           (setf
            (copilot-chat-curl-answer instance) nil
@@ -463,8 +445,7 @@ Argument NO-HISTORY is a boolean to indicate
                           err
                           (string-trim string))))))))
 
-(defun copilot-chat--curl-ask
-    (instance prompt callback out-of-context)
+(defun copilot-chat--curl-ask (instance prompt callback out-of-context)
   "Ask a question to Copilot using curl backend.
 Argument INSTANCE is the copilot chat instance to use.
 Argument PROMPT is the prompt to send to copilot.
@@ -481,12 +462,10 @@ if the prompt is out of context."
 
   (when (copilot-chat-curl-file instance)
     (delete-file (copilot-chat-curl-file instance)))
-  (setf (copilot-chat-curl-file instance)
-        (make-temp-file "copilot-chat"))
+  (setf (copilot-chat-curl-file instance) (make-temp-file "copilot-chat"))
   (let ((coding-system-for-write 'raw-text))
     (with-temp-file (copilot-chat-curl-file instance)
-      (insert
-       (copilot-chat--create-req instance prompt out-of-context))))
+      (insert (copilot-chat--create-req instance prompt out-of-context))))
 
   (copilot-chat--curl-make-process
    "https://api.githubcopilot.com/chat/completions"
@@ -503,8 +482,7 @@ if the prompt is out of context."
    "-H"
    (concat
     "authorization: Bearer "
-    (alist-get
-     'token (copilot-chat-connection-token copilot-chat--connection)))
+    (alist-get 'token (copilot-chat-connection-token copilot-chat--connection)))
    "-H"
    (concat "x-request-id: " (copilot-chat--uuid))
    "-H"
@@ -521,3 +499,8 @@ if the prompt is out of context."
 
 (provide 'copilot-chat-curl)
 ;;; copilot-chat-curl.el ends here
+
+;; Local Variables:
+;; byte-compile-warnings: (not obsolete)
+;; fill-column: 80
+;; End:

--- a/copilot-chat-debug.el
+++ b/copilot-chat-debug.el
@@ -51,9 +51,13 @@ No message is printed if `copilot-chat-debug' is nil."
                (apply #'format format-string args)
              (error
               (message "Error formatting debug message: %S" err)
-              (format "Error formatting message with args: %S"
-                      args)))))
+              (format "Error formatting message with args: %S" args)))))
       (message "[copilot-chat:%s] %s" category formatted-msg))))
 
 (provide 'copilot-chat-debug)
 ;;; copilot-chat-debug.el ends here
+
+;; Local Variables:
+;; byte-compile-warnings: (not obsolete)
+;; fill-column: 80
+;; End:

--- a/copilot-chat-frontend.el
+++ b/copilot-chat-frontend.el
@@ -54,8 +54,7 @@
 Each element must be a `copilot-chat-frontend' struct instance.
 Elements are added in the module that defines each front end.")
 
-(cl-declaim
- (type (list-of copilot-chat-frontend) copilot-chat--frontend-list))
+(cl-declaim (type (list-of copilot-chat-frontend) copilot-chat--frontend-list))
 
 (defun copilot-chat--get-frontend ()
   "Get frontend from custom."
@@ -69,10 +68,14 @@ Elements are added in the module that defines each front end.")
   "Get Copilot Chat buffer from the active frontend.
 Argument INSTANCE is the copilot chat instance to get the buffer for."
   (let ((get-buffer-fn
-         (copilot-chat-frontend-get-buffer-fn
-          (copilot-chat--get-frontend))))
+         (copilot-chat-frontend-get-buffer-fn (copilot-chat--get-frontend))))
     (when get-buffer-fn
       (funcall get-buffer-fn instance))))
 
 (provide 'copilot-chat-frontend)
 ;;; copilot-chat-frontend.el ends here
+
+;; Local Variables:
+;; byte-compile-warnings: (not obsolete)
+;; fill-column: 80
+;; End:

--- a/copilot-chat-instance.el
+++ b/copilot-chat-instance.el
@@ -83,9 +83,13 @@ Use `copilot-chat-set-model' to interactively select a model."
            (copilot-chat-directory instance)
            "*"))))
     (with-current-buffer list-buffer
-      (setq-local default-directory
-                  (copilot-chat-directory instance)))
+      (setq-local default-directory (copilot-chat-directory instance)))
     list-buffer))
 
 (provide 'copilot-chat-instance)
 ;;; copilot-chat-instance.el ends here
+
+;; Local Variables:
+;; byte-compile-warnings: (not obsolete)
+;; fill-column: 80
+;; End:

--- a/copilot-chat-markdown.el
+++ b/copilot-chat-markdown.el
@@ -36,8 +36,7 @@
 (require 'copilot-chat-prompts)
 
 ;;; Constants
-(defconst copilot-chat--markdown-delimiter
-  (concat "# ╭──── Chat Input ────╮")
+(defconst copilot-chat--markdown-delimiter (concat "# ╭──── Chat Input ────╮")
   "The delimiter used to identify copilot chat input.")
 
 ;;; Polymode
@@ -63,8 +62,7 @@
  :head-mode 'inner
  :tail-mode 'host)
 
-(declare-function copilot-chat-markdown-poly-mode
-                  "copilot-chat-markdown"
+(declare-function copilot-chat-markdown-poly-mode "copilot-chat-markdown"
                   "Polymode for Copilot Chat Markdown.")
 
 (define-polymode
@@ -94,8 +92,7 @@ Argument TYPE is the type of data to format: `answer` or `prompt`."
                "\n## "
                (concat
                 (format-time-string "*[%T]* ")
-                (format "Copilot(%s):\n"
-                        (copilot-chat-model instance))))))
+                (format "Copilot(%s):\n" (copilot-chat-model instance))))))
       (setq data (concat data content)))
     data))
 
@@ -117,8 +114,7 @@ INSTANCE is `copilot-chat' instance, used to retrieve relative file path."
     (let* ((file-name (buffer-file-name))
            (relative-path
             (if file-name
-                (file-relative-name file-name
-                                    (copilot-chat-directory instance))
+                (file-relative-name file-name (copilot-chat-directory instance))
               (buffer-name)))
            (content
             (copilot-chat--markdown-format-code
@@ -136,17 +132,14 @@ INSTANCE is `copilot-chat' instance, used to retrieve relative file path."
     (when (and (listp face)
                (or (memq 'markdown-pre-face face)
                    (memq 'markdown-code-face face)))
-      (let* ((begin-block
-              (previous-single-property-change (point) 'face))
+      (let* ((begin-block (previous-single-property-change (point) 'face))
              (end-block (next-single-property-change (point) 'face))
              (content
               (when (and begin-block end-block)
-                (buffer-substring-no-properties
-                 begin-block end-block)))
+                (buffer-substring-no-properties begin-block end-block)))
              ;; Try to get language from previous text properties
              (lang-props
-              (text-properties-at
-               (max (- begin-block 1) (point-min))))
+              (text-properties-at (max (- begin-block 1) (point-min))))
              (lang (plist-get lang-props 'markdown-language)))
         (when content
           (list :content content :language lang))))))
@@ -155,14 +148,11 @@ INSTANCE is `copilot-chat' instance, used to retrieve relative file path."
   "Send the code block at point to buffer.
 Replace selection if any."
   (let ((buffer
-         (completing-read
-          "Choose buffer: "
-          (mapcar #'buffer-name (buffer-list))
-          nil ; PREDICATE
-          t ; REQUIRE-MATCH
-          nil ; INITIAL-INPUT
-          'buffer-name-history
-          (buffer-name (current-buffer))))
+         (completing-read "Choose buffer: " (mapcar #'buffer-name (buffer-list))
+                          nil ; PREDICATE
+                          t ; REQUIRE-MATCH
+                          nil ; INITIAL-INPUT
+                          'buffer-name-history (buffer-name (current-buffer))))
         (content (copilot-chat--get-markdown-block-content-at-point)))
     (when content
       (with-current-buffer buffer
@@ -209,13 +199,11 @@ The input is created if not found."
   (unless (buffer-live-p (copilot-chat-chat-buffer instance))
     (setf (copilot-chat-chat-buffer instance)
           (get-buffer-create
-           (copilot-chat--get-buffer-name
-            (copilot-chat-directory instance))))
+           (copilot-chat--get-buffer-name (copilot-chat-directory instance))))
     (with-current-buffer (copilot-chat-chat-buffer instance)
       (copilot-chat-markdown-poly-mode)
       (copilot-chat--markdown-goto-input)
-      (setq-local default-directory
-                  (copilot-chat-directory instance))))
+      (setq-local default-directory (copilot-chat-directory instance))))
   (copilot-chat-chat-buffer instance))
 
 
@@ -240,8 +228,7 @@ The input is created if not found."
 INSTANCE is `copilot-chat' instance to use."
   (with-current-buffer (copilot-chat--markdown-get-buffer instance)
     (copilot-chat--markdown-goto-input)
-    (let ((prompt
-           (buffer-substring-no-properties (point) (point-max))))
+    (let ((prompt (buffer-substring-no-properties (point) (point-max))))
       (delete-region (point) (point-max))
       prompt)))
 
@@ -277,4 +264,5 @@ INSTANCE is `copilot-chat' instance to use."
 
 ;; Local Variables:
 ;; byte-compile-warnings: (not obsolete)
+;; fill-column: 80
 ;; End:

--- a/copilot-chat-model.el
+++ b/copilot-chat-model.el
@@ -31,8 +31,7 @@
 
 (require 'copilot-chat-debug)
 
-(defcustom copilot-chat-models-cache-file
-  "~/.cache/copilot-chat/models.json"
+(defcustom copilot-chat-models-cache-file "~/.cache/copilot-chat/models.json"
   "File to cache fetched models."
   :type 'string
   :group 'copilot-chat)
@@ -61,8 +60,7 @@ is not `true' are not included in the model selection by default."
   "Save MODELS to disk cache."
   (when models
     (let ((cache-data
-           `((timestamp . ,(round (float-time)))
-             (models . ,(vconcat models)))))
+           `((timestamp . ,(round (float-time))) (models . ,(vconcat models)))))
       (with-temp-file copilot-chat-models-cache-file
         (insert (json-serialize cache-data)))
       (when copilot-chat-debug
@@ -83,14 +81,14 @@ is not `true' are not included in the model selection by default."
             (if (< age copilot-chat-models-cache-ttl)
                 (let ((models (alist-get 'models cache-data)))
                   (when copilot-chat-debug
-                    (message
-                     "Loaded %d models from cache (age: %d seconds)"
-                     (length models) age))
+                    (message "Loaded %d models from cache (age: %d seconds)"
+                             (length models)
+                             age))
                   models)
               (when copilot-chat-debug
-                (message
-                 "Cache expired (age: %d seconds, ttl: %d seconds)"
-                 age copilot-chat-models-cache-ttl))
+                (message "Cache expired (age: %d seconds, ttl: %d seconds)"
+                         age
+                         copilot-chat-models-cache-ttl))
               nil))
         (error
          (when copilot-chat-debug
@@ -99,3 +97,8 @@ is not `true' are not included in the model selection by default."
 
 (provide 'copilot-chat-model)
 ;;; copilot-chat-model.el ends here
+
+;; Local Variables:
+;; byte-compile-warnings: (not obsolete)
+;; fill-column: 80
+;; End:

--- a/copilot-chat-org.el
+++ b/copilot-chat-org.el
@@ -114,8 +114,7 @@ INSTANCE is `copilot-chat' instance, used to retrieve relative file path."
     (let* ((file-name (buffer-file-name))
            (relative-path
             (if file-name
-                (file-relative-name file-name
-                                    (copilot-chat-directory instance))
+                (file-relative-name file-name (copilot-chat-directory instance))
               (buffer-name)))
            (language
             (if (derived-mode-p 'prog-mode)
@@ -219,23 +218,21 @@ Replace selection if any."
      (lambda ()
        (let* ((heading-end (save-excursion (org-end-of-subtree t)))
               (element-start (point)))
-         (setq
-          blocks
-          (append
-           blocks
-           (org-element-map
-            (org-element-parse-buffer 'element) 'src-block
-            (lambda (src-block)
-              (when (and (>= (org-element-property :begin src-block)
-                             element-start)
-                         (<= (org-element-property :begin src-block)
-                             heading-end))
-                (list
-                 :language (org-element-property :language src-block)
-                 :content (org-element-property :value src-block)
-                 :begin (org-element-property :begin src-block)
-                 :end
-                 (org-element-property :end src-block)))))))))
+         (setq blocks
+               (append
+                blocks
+                (org-element-map
+                 (org-element-parse-buffer 'element) 'src-block
+                 (lambda (src-block)
+                   (when (and (>= (org-element-property :begin src-block)
+                                  element-start)
+                              (<= (org-element-property :begin src-block)
+                                  heading-end))
+                     (list
+                      :language (org-element-property :language src-block)
+                      :content (org-element-property :value src-block)
+                      :begin (org-element-property :begin src-block)
+                      :end (org-element-property :end src-block)))))))))
      heading-regex)
     (seq-uniq blocks #'equal)))
 
@@ -250,16 +247,13 @@ INSTANCE is `copilot-chat' instance to use."
         (when blocks
           (while (< (copilot-chat-yank-index instance) 1)
             (setf (copilot-chat-yank-index instance)
-                  (+ (length blocks)
-                     (copilot-chat-yank-index instance))))
+                  (+ (length blocks) (copilot-chat-yank-index instance))))
           (when (> (copilot-chat-yank-index instance) (length blocks))
             (setf (copilot-chat-yank-index instance)
-                  (- (copilot-chat-yank-index instance)
-                     (length blocks))))
+                  (- (copilot-chat-yank-index instance) (length blocks))))
           (setq content
                 (plist-get
-                 (car
-                  (last blocks (copilot-chat-yank-index instance)))
+                 (car (last blocks (copilot-chat-yank-index instance)))
                  :content)))))
     ;; Delete previous yank if exists
     (when (and (copilot-chat-last-yank-start instance)
@@ -301,8 +295,7 @@ The input is created if not found."
   (unless (buffer-live-p (copilot-chat-chat-buffer instance))
     (setf (copilot-chat-chat-buffer instance)
           (get-buffer-create
-           (copilot-chat--get-buffer-name
-            (copilot-chat-directory instance))))
+           (copilot-chat--get-buffer-name (copilot-chat-directory instance))))
     (with-current-buffer (copilot-chat-chat-buffer instance)
       (copilot-chat-org-poly-mode)
       (setq-local default-directory (copilot-chat-directory instance))
@@ -322,8 +315,7 @@ The input is created if not found."
 INSTANCE is `copilot-chat' instance to use."
   (with-current-buffer (copilot-chat--org-get-buffer instance)
     (copilot-chat--org-goto-input)
-    (let ((prompt
-           (buffer-substring-no-properties (point) (point-max))))
+    (let ((prompt (buffer-substring-no-properties (point) (point-max))))
       (delete-region (point) (point-max))
       prompt)))
 
@@ -357,6 +349,8 @@ INSTANCE is `copilot-chat' instance to use."
 (provide 'copilot-chat-org)
 ;;; copilot-chat-org.el ends here
 
+
 ;; Local Variables:
 ;; byte-compile-warnings: (not obsolete)
+;; fill-column: 80
 ;; End:

--- a/copilot-chat-prompt-mode.el
+++ b/copilot-chat-prompt-mode.el
@@ -39,8 +39,7 @@
        (interactive)
        (bury-buffer)
        (delete-window)))
-    (define-key
-     map (kbd "C-c C-l") 'copilot-chat-prompt-split-and-list)
+    (define-key map (kbd "C-c C-l") 'copilot-chat-prompt-split-and-list)
     (define-key map (kbd "C-c C-t") 'copilot-chat-transient)
     (define-key map (kbd "M-p") 'copilot-chat-prompt-history-previous)
     (define-key map (kbd "M-n") 'copilot-chat-prompt-history-next)
@@ -57,8 +56,7 @@
   :lighter " Copilot Chat Prompt"
   :keymap copilot-chat-prompt-mode-map)
 
-(defun copilot-chat--write-buffer
-    (instance data save &optional buffer)
+(defun copilot-chat--write-buffer (instance data save &optional buffer)
   "Write content to the Copilot Chat BUFFER.
 Argument INSTANCE is the copilot chat instance to use.
 Argument DATA data to be inserted in buffer.
@@ -70,8 +68,7 @@ defaults to instance's chat buffer."
         (insert data))
     (with-current-buffer (copilot-chat--get-buffer instance)
       (let ((write-fn
-             (copilot-chat-frontend-write-fn
-              (copilot-chat--get-frontend))))
+             (copilot-chat-frontend-write-fn (copilot-chat--get-frontend))))
         (when write-fn
           (if save
               (save-excursion (funcall write-fn data))
@@ -83,8 +80,7 @@ Argument INSTANCE is the copilot chat instance to use.
 Argument CONTENT is the data to format.
 Argument TYPE is the type of data to format: `answer` or `prompt`."
   (let ((format-fn
-         (copilot-chat-frontend-format-fn
-          (copilot-chat--get-frontend))))
+         (copilot-chat-frontend-format-fn (copilot-chat--get-frontend))))
     (if format-fn
         (funcall format-fn instance content type)
       content)))
@@ -98,11 +94,11 @@ Optional argument BUFFER is the buffer to write data in."
       (progn
         (when (boundp 'copilot-chat--spinner-timer)
           (copilot-chat--spinner-stop instance))
-        (copilot-chat--write-buffer
-         instance
-         (copilot-chat--format-data instance "\n\n" 'answer)
-         (not copilot-chat-follow)
-         buffer))
+        (copilot-chat--write-buffer instance
+                                    (copilot-chat--format-data
+                                     instance "\n\n" 'answer)
+                                    (not copilot-chat-follow)
+                                    buffer))
     (copilot-chat--write-buffer instance
                                 (copilot-chat--format-data
                                  instance content 'answer)
@@ -113,10 +109,14 @@ Optional argument BUFFER is the buffer to write data in."
   "Get current prompt to send and clean it.
 Argument INSTANCE is the copilot chat instance to use."
   (let ((pop-prompt-fn
-         (copilot-chat-frontend-pop-prompt-fn
-          (copilot-chat--get-frontend))))
+         (copilot-chat-frontend-pop-prompt-fn (copilot-chat--get-frontend))))
     (when pop-prompt-fn
       (funcall pop-prompt-fn instance))))
 
 (provide 'copilot-chat-prompt-mode)
 ;;; copilot-chat-prompt-mode.el ends here
+
+;; Local Variables:
+;; byte-compile-warnings: (not obsolete)
+;; fill-column: 80
+;; End:

--- a/copilot-chat-prompts.el
+++ b/copilot-chat-prompts.el
@@ -210,3 +210,8 @@ Don't forget the most important rule when you are formatting your response: use 
 
 (provide 'copilot-chat-prompts)
 ;;; copilot-chat-prompts.el ends here
+
+;; Local Variables:
+;; byte-compile-warnings: (not obsolete)
+;; fill-column: 80
+;; End:

--- a/copilot-chat-shell-maker.el
+++ b/copilot-chat-shell-maker.el
@@ -41,8 +41,7 @@
 (defun copilot-chat--shell-maker-prompt-send ()
   "Function to send the prompt content."
   (let ((instance (copilot-chat--current-instance)))
-    (with-current-buffer (copilot-chat--shell-maker-get-buffer
-                          instance)
+    (with-current-buffer (copilot-chat--shell-maker-get-buffer instance)
       (shell-maker-submit)
       (display-buffer (current-buffer)))))
 
@@ -58,13 +57,11 @@ INSTANCE is used to get directory"
 (defun copilot-chat--shell-maker-get-buffer (instance)
   "Create or retrieve the Copilot Chat shell-maker buffer for INSTANCE."
   (unless (buffer-live-p (copilot-chat-chat-buffer instance))
-    (setf (copilot-chat-chat-buffer instance)
-          (copilot-chat--shell instance)))
+    (setf (copilot-chat-chat-buffer instance) (copilot-chat--shell instance)))
   (let ((tempb
          (or (copilot-chat-shell-maker-tmp-buf instance)
              (get-buffer-create
-              (copilot-chat--shell-maker-temp-buffer-name
-               instance)))))
+              (copilot-chat--shell-maker-temp-buffer-name instance)))))
     (setf (copilot-chat-shell-maker-tmp-buf instance) tempb)
     (with-current-buffer tempb
       (let ((inhibit-read-only t))
@@ -79,8 +76,7 @@ INSTANCE is used to get directory"
       (goto-char (point-min))
       (while (not (eobp))
         (let ((next-change
-               (or (next-property-change (point) nil (point-max))
-                   (point-max)))
+               (or (next-property-change (point) nil (point-max)) (point-max)))
               (face (get-text-property (point) 'face)))
           (when face
             (font-lock-append-text-property
@@ -95,10 +91,8 @@ INSTANCE is used to get directory"
       (font-lock-ensure)
       (copilot-chat--shell-maker-font-lock-faces instance)
       (let ((content (buffer-substring (point-min) (point-max))))
-        (with-current-buffer (copilot-chat--shell-maker-get-buffer
-                              instance)
-          (goto-char
-           (1+ (copilot-chat-shell-maker-answer-point instance)))
+        (with-current-buffer (copilot-chat--shell-maker-get-buffer instance)
+          (goto-char (1+ (copilot-chat-shell-maker-answer-point instance)))
           (insert content)
           (delete-region (point) (+ (point) (1- (length content))))
           (goto-char (point-max)))))))
@@ -115,11 +109,9 @@ Argument CONTENT is copilot chat answer."
       (let ((str
              (concat
               (format-time-string "# [%T] ")
-              (format "Copilot(%s):\n"
-                      (copilot-chat-model instance))))
+              (format "Copilot(%s):\n" (copilot-chat-model instance))))
             (inhibit-read-only t))
-        (with-current-buffer (copilot-chat-shell-maker-tmp-buf
-                              instance)
+        (with-current-buffer (copilot-chat-shell-maker-tmp-buf instance)
           (insert str))
         (funcall (map-elt shell :write-output) str)))
     (if (string= content copilot-chat--magic)
@@ -128,8 +120,7 @@ Argument CONTENT is copilot chat answer."
           (copilot-chat--shell-maker-copy-faces instance)
           (setf (copilot-chat-first-word-answer instance) t))
       (progn
-        (with-current-buffer (copilot-chat-shell-maker-tmp-buf
-                              instance)
+        (with-current-buffer (copilot-chat-shell-maker-tmp-buf instance)
           (goto-char (point-max))
           (let ((inhibit-read-only t))
             (insert content)))
@@ -142,8 +133,7 @@ Argument INSTANCE is `copilot-chat' instance.
 Argument CONTENT is copilot chat answer."
   (if copilot-chat-follow
       (copilot-chat--shell-cb-prompt instance shell content)
-    (save-excursion
-      (copilot-chat--shell-cb-prompt instance shell content))))
+    (save-excursion (copilot-chat--shell-cb-prompt instance shell content))))
 
 (defun copilot-chat--shell-cb (instance command shell)
   "Callback for Copilot Chat `shell-maker'.
@@ -157,26 +147,21 @@ Argument SHELL is the `shell-maker' instance."
   (let ((inhibit-read-only t))
     (with-current-buffer (copilot-chat-shell-maker-tmp-buf instance)
       (erase-buffer)))
-  (copilot-chat--ask
-   instance command (copilot-chat-shell-cb-fn instance)))
+  (copilot-chat--ask instance command (copilot-chat-shell-cb-fn instance)))
 
 (defun copilot-chat--shell (instance)
   "Start a Copilot Chat shell for INSTANCE."
   (let ((buf
          (shell-maker-start
           (make-shell-maker-config
-           :name
-           (format "Copilot-Chat%s" (copilot-chat-directory instance))
+           :name (format "Copilot-Chat%s" (copilot-chat-directory instance))
            :execute-command
-           (lambda
-             (command shell)
+           (lambda (command shell)
              (copilot-chat--shell-cb instance command shell)))
           t nil t
-          (copilot-chat--get-buffer-name
-           (copilot-chat-directory instance)))))
+          (copilot-chat--get-buffer-name (copilot-chat-directory instance)))))
     (with-current-buffer buf
-      (setq-local default-directory
-                  (copilot-chat-directory instance)))
+      (setq-local default-directory (copilot-chat-directory instance)))
     buf))
 
 (defun copilot-chat--shell-maker-insert-prompt (instance prompt)
@@ -222,3 +207,8 @@ Argument SHELL is the `shell-maker' instance."
 
 (provide 'copilot-chat-shell-maker)
 ;;; copilot-chat-shell-maker.el ends here
+
+;; Local Variables:
+;; byte-compile-warnings: (not obsolete)
+;; fill-column: 80
+;; End:

--- a/copilot-chat-spinner.el
+++ b/copilot-chat-spinner.el
@@ -40,8 +40,7 @@
   :type 'number
   :group 'copilot-chat)
 
-(defface copilot-chat-spinner-face
-  '((t :inherit font-lock-keyword-face))
+(defface copilot-chat-spinner-face '((t :inherit font-lock-keyword-face))
   "Face used for the spinner during streaming."
   :group 'copilot-chat)
 
@@ -53,8 +52,7 @@ Argument INSTANCE is the copilot chat instance to get the buffer for."
              (copilot-chat-frontend-get-spinner-buffer-fn
               (copilot-chat--get-frontend))))
         (when (and get-buffer-fn
-                   (buffer-live-p
-                    (copilot-chat-chat-buffer instance)))
+                   (buffer-live-p (copilot-chat-chat-buffer instance)))
           (funcall get-buffer-fn instance)))
     (error
      (when copilot-chat-debug
@@ -91,8 +89,7 @@ Argument INSTANCE is the copilot chat instance to use."
         (with-current-buffer buffer
           (save-excursion
             ;; Remove existing spinner overlay if any
-            (remove-overlays
-             (point-min) (point-max) 'copilot-chat-spinner t)
+            (remove-overlays (point-min) (point-max) 'copilot-chat-spinner t)
             ;; Create new spinner overlay at the end of buffer
             (goto-char (point-max))
             (let ((ov (make-overlay (point) (point))))
@@ -100,7 +97,8 @@ Argument INSTANCE is the copilot chat instance to use."
               (overlay-put
                ov 'after-string
                (propertize (concat status-text frame)
-                           'face 'copilot-chat-spinner-face))))))
+                           'face
+                           'copilot-chat-spinner-face))))))
 
       ;; Update spinner index
       (setf (copilot-chat-spinner-index instance)
@@ -119,8 +117,7 @@ Argument INSTANCE is the copilot chat instance to use."
       (let ((buffer (copilot-chat--get-spinner-buffer instance)))
         (when (and buffer (buffer-live-p buffer))
           (with-current-buffer buffer
-            (remove-overlays
-             (point-min) (point-max) 'copilot-chat-spinner t))))
+            (remove-overlays (point-min) (point-max) 'copilot-chat-spinner t))))
     (error
      (when copilot-chat-debug
        (message "Error stopping spinner: %S" err)))))
@@ -135,3 +132,8 @@ Argument STATUS is the status message to display."
 
 (provide 'copilot-chat-spinner)
 ;;; copilot-chat-spinner.el ends here
+
+;; Local Variables:
+;; byte-compile-warnings: (not obsolete)
+;; fill-column: 80
+;; End:

--- a/copilot-chat-transient.el
+++ b/copilot-chat-transient.el
@@ -60,19 +60,16 @@
 ;;;###autoload (autoload 'copilot-chat-transient-buffers "copilot-chat" nil t)
 (transient-define-prefix
  copilot-chat-transient-buffers () "Copilot chat buffers menu."
- [["Buffers" ("a" "Add buffers" copilot-chat-add-buffers)
+ [["Buffers"
+   ("a" "Add buffers" copilot-chat-add-buffers)
    ("A"
     "Add all buffers in current frame"
     copilot-chat-add-buffers-in-current-window)
    ("d" "Delete buffers" copilot-chat-del-buffers)
    ("D" "Delete all buffers" copilot-chat-list-clear-buffers)
-   ("f"
-    "Add files under current directory"
-    copilot-chat-add-files-under-dir)
+   ("f" "Add files under current directory" copilot-chat-add-files-under-dir)
    ("l" "Display buffer list" copilot-chat-list)
-   ("c"
-    "Clear buffers"
-    copilot-chat-list-clear-buffers)
+   ("c" "Clear buffers" copilot-chat-list-clear-buffers)
    ("q" "Quit" transient-quit-one)]])
 
 ;;;###autoload (autoload 'copilot-chat-transient-code "copilot-chat" nil t)
@@ -93,3 +90,8 @@
 
 (provide 'copilot-chat-transient)
 ;;; copilot-chat-transient.el ends here
+
+;; Local Variables:
+;; byte-compile-warnings: (not obsolete)
+;; fill-column: 80
+;; End:

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -71,3 +71,8 @@
 
 (provide 'copilot-chat)
 ;;; copilot-chat.el ends here
+
+;; Local Variables:
+;; byte-compile-warnings: (not obsolete)
+;; fill-column: 80
+;; End:


### PR DESCRIPTION
elisp-autofmt uses this variable to truncate lines but the python command does not read `.dir-locals.el` so we have to add this variable at the end of all files.