### PR TITLE
feat(vision): add dynamic vision support for Copilot Chat

### DIFF
--- a/copilot-chat-curl.el
+++ b/copilot-chat-curl.el
@@ -128,12 +128,14 @@ Arguments ARGS are additional arguments to pass to curl."
       (when (/= result 0)
         (error (format "curl returned non-zero result: %d" result))))))
 
-(defun copilot-chat--curl-make-process (address method data filter &rest args)
+(defun copilot-chat--curl-make-process
+    (address method data filter vision &rest args)
   "Call curl asynchronously.
 Argument ADDRESS is the URL to call.
 Argument METHOD is the HTTP method to use.
 Argument DATA is the data to send.
 Argument FILTER is the function called to parse data.
+If VISION is t, add vision header.
 Optional argument ARGS are additional arguments to pass to curl."
   (let ((command
          (append
@@ -154,9 +156,9 @@ Optional argument ARGS are additional arguments to pass to curl."
            "-H"
            "editor-plugin-version: CopilotChat.nvim/2.0.0"
            "-H"
-           "editor-version: Neovim/0.10.0"
-           "-H"
-           "Copilot-Vision-Request: true")
+           "editor-version: Neovim/0.10.0")
+          (when vision
+            (list "-H" "Copilot-Vision-Request: true"))
           (when data
             (list "-d" data))
           (when copilot-chat-curl-proxy
@@ -480,6 +482,7 @@ if the prompt is out of context."
           instance string callback out-of-context)
        (copilot-chat--curl-analyze-nonstream-response
         instance proc string callback out-of-context)))
+   (copilot-chat-uses-vision instance)
    "-H"
    "openai-intent: conversation-panel"
    "-H"

--- a/copilot-chat-instance.el
+++ b/copilot-chat-instance.el
@@ -46,6 +46,7 @@ Use `copilot-chat-set-model' to interactively select a model."
  (first-word-answer t :type boolean)
  (history nil :type list)
  (buffers nil :type list)
+ (uses-vision nil :type boolean)
  (prompt-history nil :type list)
  (prompt-history-position nil :type (or null int))
  (yank-index 1 :type int)

--- a/copilot-chat-request.el
+++ b/copilot-chat-request.el
@@ -198,7 +198,10 @@ if the prompt is out of context."
        ("content-type" . "application/json")
        ("user-agent" . "CopilotChat.nvim/2.0.0")
        ("editor-plugin-version" . "CopilotChat.nvim/2.0.0")
-       ("Copilot-Vision-Request" . "true")
+       ("Copilot-Vision-Request" .
+        ,(if (copilot-chat-uses-vision instance)
+             "true"
+           "false"))
        ("authorization" .
         ,(concat
           "Bearer "


### PR DESCRIPTION
- Introduced `uses-vision` property to track vision usage per instance
- Enhanced message handling to reset vision state after processing
- Improved curl process to dynamically add vision header when needed
- Updated request headers to conditionally include vision support

fixes #185