### PR TITLE
feat(chat): add cancel functionality for Copilot Chat requests

### DIFF
--- a/copilot-chat-backend.el
+++ b/copilot-chat-backend.el
@@ -42,6 +42,7 @@
  login-fn
  renew-token-fn
  ask-fn
+ cancel-fn
  quotas-fn)
 
 (cl-declaim (type (list-of copilot-chat-backend) copilot-chat--backend-list))

--- a/copilot-chat-command.el
+++ b/copilot-chat-command.el
@@ -992,6 +992,13 @@ All its associated buffers are killed."
   (interactive)
   (copilot-chat--quotas))
 
+;;;###autoload (autoload 'copilot-chat-cancel "copilot-chat" nil t)
+(defun copilot-chat-cancel ()
+  "Cancel the current Copilot Chat request."
+  (interactive)
+  (let ((instance (copilot-chat--current-instance)))
+    (copilot-chat--cancel instance)))
+
 
 (provide 'copilot-chat-command)
 ;;; copilot-chat-command.el ends here

--- a/copilot-chat-copilot.el
+++ b/copilot-chat-copilot.el
@@ -473,6 +473,15 @@ Argument DIRECTORY is the path to search for matching instance."
           (goto-char (point-min))
           (display-buffer (current-buffer)))))))
 
+
+(defun copilot-chat--cancel (instance)
+  "Cancel the current request in the copilot chat INSTANCE."
+  (let ((cancel-fn
+         (copilot-chat-backend-cancel-fn (copilot-chat--get-backend))))
+    (when cancel-fn
+      (funcall cancel-fn instance)
+      (message "Request cancelled."))))
+
 (provide 'copilot-chat-copilot)
 ;;; copilot-chat-copilot.el ends here
 


### PR DESCRIPTION
- Introduced `cancel-fn` in backend definitions to support request cancellation.
- Added `copilot-chat-cancel` command for user-initiated cancellations.
- Implemented backend-specific cancellation logic for curl and request backends.
- Enhanced instance management to handle process termination and cleanup.

fixes #198