### PR TITLE
feat: default Copilot chat model to gpt-4.1

### DIFF
--- a/copilot-chat-instance.el
+++ b/copilot-chat-instance.el
@@ -29,7 +29,7 @@
 (require 'polymode)
 
 ;; GitHub Copilot models: https://api.githubcopilot.com/models
-(defcustom copilot-chat-default-model "gpt-4o"
+(defcustom copilot-chat-default-model "gpt-4.1"
   "The model to use for Copilot chat.
 The list of available models will be updated when fetched from the API.
 Use `copilot-chat-set-model' to interactively select a model."


### PR DESCRIPTION
GPT-4.1 cost equal to GPT-4o.
[Requests in GitHub Copilot - GitHub Docs](https://docs.github.com/en/copilot/concepts/billing/copilot-requests)
And GitHub default model is `gpt-4.1` often.
