### PR TITLE
auth: guard token expiry check to prevent number-or-marker-p error

### DIFF
--- a/copilot-chat-copilot.el
+++ b/copilot-chat-copilot.el
@@ -208,14 +208,13 @@ Then we need a session token."
                 (json-read-from-string
                  (buffer-substring-no-properties (point-min) (point-max))))))))
 
-  (when (or (null (copilot-chat-connection-token copilot-chat--connection))
-            (let* ((token (copilot-chat-connection-token copilot-chat--connection))
-                   (expires-at (and (listp token) (alist-get 'expires_at token)))
-                   (now (round (float-time (current-time)))))
-              ;; Renew token if missing, malformed, or expired.
-              (or (null token)
-                  (null expires-at)
-                  (and (numberp expires-at) (> now expires-at)))))
+  (when (let* ((token (copilot-chat-connection-token copilot-chat--connection))
+               (expires-at (and (listp token) (alist-get 'expires_at token)))
+               (now (round (float-time (current-time)))))
+          ;; Renew token if missing, malformed, or expired.
+          (or (null token)
+              (null expires-at)
+              (and (numberp expires-at) (> now expires-at))))
     (copilot-chat--renew-token))
   (setf (copilot-chat-connection-ready copilot-chat--connection) t))
 


### PR DESCRIPTION
The authentication flow crashed when a cached Copilot session token lacked a numeric expires_at field. In that case the code evaluated:

    (> (round (float-time (current-time))) (alist-get 'expires_at token))

which passed nil as the second argument to >, raising: Wrong type argument: number-or-marker-p, nil This surfaced to users as: copilot-chat--ask:

    'Wrong type argument: number-or-marker-p, nil'

and also caused background model fetch to log:

'Failed to fetch models in background: Wrong type argument: number-or-marker-p, nil'