### PR TITLE
    Remove the redundant "copilot-integration-id: vscode-chat"

### DIFF
--- a/copilot-chat-curl.el
+++ b/copilot-chat-curl.el
@@ -638,9 +638,7 @@ if the prompt is out of context."
    "-H"
    (concat
     "vscode-machineid: "
-    (copilot-chat-connection-machineid copilot-chat--connection))
-   "-H"
-   "copilot-integration-id: vscode-chat"))
+    (copilot-chat-connection-machineid copilot-chat--connection))))
 
 (defun copilot-chat--curl-cancel (instance)
   "Cancel the current request for INSTANCE."


### PR DESCRIPTION
    header in copilot-chat--curl-ask.
    This will already be added by copilot-chat--curl-make-process.
    Adding it 2x results in GitHub replying with: bad request: unknown Copilot-Integration-Id.