### PR TITLE
feat(auth): share token with copilot.el

### DIFF
--- a/copilot-chat-common.el
+++ b/copilot-chat-common.el
@@ -44,7 +44,7 @@
   :type 'boolean
   :group 'copilot-chat)
 
-(defcustom copilot-chat-github-token-file "~/.config/copilot-chat/github-token"
+(defcustom copilot-chat-github-token-file "~/.config/github-copilot/apps.json"
   "The file where to find GitHub token."
   :type 'string
   :group 'copilot-chat)

--- a/copilot-chat-curl.el
+++ b/copilot-chat-curl.el
@@ -208,15 +208,9 @@ Optional argument ARGS are additional arguments to pass to curl."
   "Curl github token request parsing."
   (goto-char (point-min))
   (let* ((json-data (json-parse-buffer :false-object :json-false))
-         (token (gethash "access_token" json-data))
-         (token-dir
-          (file-name-directory
-           (expand-file-name copilot-chat-github-token-file))))
+         (token (gethash "access_token" json-data)))
     (setf (copilot-chat-connection-github-token copilot-chat--connection) token)
-    (when (not (file-directory-p token-dir))
-      (make-directory token-dir t))
-    (with-temp-file copilot-chat-github-token-file
-      (insert token))))
+    (copilot-chat--write-cached-token token)))
 
 (defun copilot-chat--curl-parse-login ()
   "Curl login request parsing."


### PR DESCRIPTION
GitHub has strengthened token management, making it necessary to use the same token for copilot.el and copilot-chat.

- Updated `copilot-chat-github-token-file` to use copilot.el token file.
- Added `copilot-chat--write-cached-token` to cache GitHub tokens in a structured JSON format.
- Enhanced `copilot-chat--get-cached-token` to parse and retrieve tokens from the new JSON-based cache.
- Refactored token handling in `copilot-chat-curl.el` to utilize the new caching mechanism.