### PR TITLE
Include untracked files in `copilot-chat--git-ls-files`

### DIFF
--- a/copilot-chat-git.el
+++ b/copilot-chat-git.el
@@ -149,7 +149,14 @@ Git.  REPO-ROOT must be git top directory."
  (let* ((default-directory repo-root)
         (ls-output
          (aio-await
-          (copilot-chat--exec "git" "--no-pager" "ls-files" "--full-name" "--cached" "--others" "--exclude-standard")))
+          (copilot-chat--exec
+           "git"
+           "--no-pager"
+           "ls-files"
+           "--full-name"
+           "--cached"
+           "--others"
+           "--exclude-standard")))
         (all-files (split-string ls-output "\n" t)))
    (mapcar (lambda (file) (expand-file-name file repo-root)) all-files)))
 


### PR DESCRIPTION
I'll preface this by saying that I don't know what the intended behavior for this situation is - the change was useful for my use case, so I would like to merge it in case others would find it useful.

When calling `copilot-chat-add-workspace`, in the case that the working directory/workspace for that chat instance is a git repo, `copilot-chat--git-ls-files` is invoked to get the list of files to be added to the context list.
https://github.com/chep/copilot-chat.el/blob/9dd4b0c72e5e2af16b340a22a427105854f4e745/copilot-chat-command.el#L876

However, this doesn't include untracked files so I added additional arguments to make sure they get included.

As per the `git ls-files --help` manpage:
```
       -c, --cached
           Show all files cached in Git’s index, i.e. all tracked files. (This is the default if no
           -c/-s/-d/-o/-u/-k/-m/--resolve-undo options are specified.)
```
```
       -o, --others
           Show other (i.e. untracked) files in the output
```
```
       --exclude-standard
           Add the standard Git exclusions: .git/info/exclude, .gitignore in each directory, and the
           user’s global exclusion file.
```