### PR TITLE
fix!: bump minimum Emacs version from 29.1 to 30.1

### DIFF
--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -5,7 +5,7 @@
 ;; Author: cedric.chepied <cedric.chepied@gmail.com>
 ;; Version: 4.0.0
 ;; URL: https://github.com/chep/copilot-chat.el
-;; Package-Requires: ((emacs "29.1") (aio "1.0") (request "0.3.2") (transient "0.8.3") (polymode "0.2.2") (org "9.4.6") (markdown-mode "2.6") (shell-maker "0.76.2") (mcp "0.1.0"))
+;; Package-Requires: ((emacs "30.1") (aio "1.0") (request "0.3.2") (transient "0.8.3") (polymode "0.2.2") (org "9.4.6") (markdown-mode "2.6") (shell-maker "0.76.2") (mcp "0.1.0"))
 ;; Keywords: convenience, tools
 
 


### PR DESCRIPTION
The dependency [mcp.el](https://github.com/lizqwerscott/mcp.el)
declares `(emacs "30.1")` in its Package-Requires,
which means copilot-chat.el was effectively incompatible
with Emacs 29.x despite claiming to support 29.1.
This was reported in discussion #233,
where users on Emacs 29.4 saw the package marked as incompatible.
Investigation confirmed that mcp.el is the source of the Emacs 30.1 requirement.
Raise the declared minimum version to match the actual requirement.
