### PR TITLE
fix(prompts): restrict commit prompt to generator-only instructions

### DIFF
--- a/copilot-chat-prompts.el
+++ b/copilot-chat-prompts.el
@@ -27,7 +27,8 @@
 
 ;;; Code:
 (defcustom copilot-chat-commit-prompt
-  "You are an expert software engineer and meticulous code reviewer.
+  "You are a commit message generator.
+Your ONLY task is to produce a Git commit message.
 Your task is to generate a single Git commit message that **strictly follows the Conventional Commits v1.0.0 Specification**.
 
 ### INPUTS PROVIDED


### PR DESCRIPTION
Delete code reviewer instructions.
Because GPT-5 mini start code review instead of commit message generation.
