### PR TITLE
feat(chat): add "allow all" option for tool calls in Copilot Chat

### DIFF
--- a/gh-copilot-chat-command.el
+++ b/gh-copilot-chat-command.el
@@ -109,7 +109,9 @@ to Copilot for processing."
          (gh-copilot-chat--format-data instance prompt 'prompt) nil)
         (with-current-buffer (gh-copilot-chat--get-buffer instance)
           (recenter-top-bottom))
-        (setf (gh-copilot-chat-prompt-history-position instance) nil)
+        (setf
+         (gh-copilot-chat-prompt-history-position instance) nil
+         (gh-copilot-chat-allow-all instance) nil)
         (gh-copilot-chat--ask instance prompt 'gh-copilot-chat-prompt-cb)))))
 
 ;;;###autoload (autoload 'gh-copilot-chat-ask-and-insert "gh-copilot-chat" nil t)

--- a/gh-copilot-chat-completions.el
+++ b/gh-copilot-chat-completions.el
@@ -90,16 +90,27 @@ Argument SEGMENT is data segment to parse."
 INSTANCE is the copilot chat instance."
   (let ((results nil))
     (dolist (function functions)
-      (let* ((connection (gh-copilot-chat--mcp-find-connection instance function))
-             (name (gh-copilot-chat-function-name function))
-             (arguments (gh-copilot-chat-function-arguments function)))
-        (if (yes-or-no-p
-             (format
-              "Copilot Chat wants to call the tool '%s' with arguments: %s. Allow?"
-              name
-              (if (string-empty-p arguments)
-                  "none"
-                arguments)))
+      (let*
+          ((connection
+            (gh-copilot-chat--mcp-find-connection instance function))
+           (name (gh-copilot-chat-function-name function))
+           (arguments (gh-copilot-chat-function-arguments function))
+           (choice
+            (if (gh-copilot-chat-allow-all instance)
+                "all"
+              (read-answer
+               (format
+                "Copilot Chat wants to call the tool '%s' with arguments: %s. Allow?"
+                name
+                (if (string-empty-p arguments)
+                    "none"
+                  arguments))
+               '(("yes" ?y "allow this call")
+                 ("no" ?n "deny this call")
+                 ("all" ?! "allow all remaining calls"))))))
+        (when (string= choice "all")
+          (setf (gh-copilot-chat-allow-all instance) t))
+        (if (or (string= choice "yes") (string= choice "all"))
             (mcp-async-call-tool
              connection name
              (if (and arguments (not (string-empty-p arguments)))
@@ -178,7 +189,8 @@ if the response should be added to history."
   ;;    the two trailing empty lines are skipped.
   (when (gh-copilot-chat-completions-current-data completions)
     (setq string
-          (concat (gh-copilot-chat-completions-current-data completions) string))
+          (concat
+           (gh-copilot-chat-completions-current-data completions) string))
     (setf (gh-copilot-chat-completions-current-data completions) nil))
 
   (let ((segments (split-string string "\n")))
@@ -205,23 +217,23 @@ if the response should be added to history."
                           "")
                        :role "assistant")))
                 (when functions
-                  (setq new-hist
-                        (append
-                         new-hist
-                         `(:tool_calls
-                           ,(vconcat
-                             (mapcar
-                              (lambda (function)
-                                `(:type
-                                  "function"
-                                  :id ,(gh-copilot-chat-function-id function)
-                                  :function
-                                  (:name
-                                   ,(gh-copilot-chat-function-name function)
-                                   :arguments
-                                   ,(gh-copilot-chat-function-arguments
-                                     function))))
-                              functions))))))
+                  (setq
+                   new-hist
+                   (append
+                    new-hist
+                    `(:tool_calls
+                      ,(vconcat
+                        (mapcar
+                         (lambda (function)
+                           `(:type
+                             "function"
+                             :id ,(gh-copilot-chat-function-id function)
+                             :function
+                             (:name
+                              ,(gh-copilot-chat-function-name function)
+                              :arguments
+                              ,(gh-copilot-chat-function-arguments function))))
+                         functions))))))
                 (when (or (not (string-empty-p answer)) functions)
                   (push new-hist (gh-copilot-chat-history instance)))))
 
@@ -252,7 +264,8 @@ if the response should be added to history."
                 (if (eq token :null)
                     (let ((tool_calls (alist-get 'tool_calls delta)))
                       (when (and tool_calls (not (eq tool_calls :null)))
-                        (setf (gh-copilot-chat-completions-functions completions)
+                        (setf (gh-copilot-chat-completions-functions
+                               completions)
                               (gh-copilot-chat--append-vector-to-functions
                                tool_calls
                                (gh-copilot-chat-completions-functions
@@ -300,7 +313,8 @@ Argument NO-HISTORY is a boolean to indicate
  if the response should be added to history."
   (when (gh-copilot-chat-completions-current-data completions)
     (setq string
-          (concat (gh-copilot-chat-completions-current-data completions) string))
+          (concat
+           (gh-copilot-chat-completions-current-data completions) string))
     (setf (gh-copilot-chat-completions-current-data completions) nil))
 
   (condition-case err
@@ -356,7 +370,8 @@ Argument PROMPT Copilot prompt to send (string or list of json objects)
 Argument NO-CONTEXT tells `gh-copilot-chat' to not send history and buffers.
 The create req function is called first and will return new prompt."
   (let* ((create-req-fn
-          (gh-copilot-chat-frontend-create-req-fn (gh-copilot-chat--get-frontend)))
+          (gh-copilot-chat-frontend-create-req-fn
+           (gh-copilot-chat--get-frontend)))
          (copilot-instruction-content
           (and gh-copilot-chat-use-copilot-instruction-files
                (gh-copilot-chat--read-copilot-instructions-file)))
@@ -386,7 +401,8 @@ The create req function is called first and will return new prompt."
     (unless no-context
       ;; Clean buffer list once and add buffer contents
       (setf (gh-copilot-chat-buffers instance)
-            (cl-remove-if-not #'buffer-live-p (gh-copilot-chat-buffers instance)))
+            (cl-remove-if-not
+             #'buffer-live-p (gh-copilot-chat-buffers instance)))
       (dolist (buffer (gh-copilot-chat-buffers instance))
         (setq messages
               (gh-copilot-chat--add-buffer-to-req buffer instance messages)))

--- a/gh-copilot-chat-instance.el
+++ b/gh-copilot-chat-instance.el
@@ -58,7 +58,8 @@ Use `gh-copilot-chat-set-model' to interactively select a model."
  (-backend nil)
  (-frontend nil)
  (file-path nil :type string)
- (mcp-servers nil))
+ (mcp-servers nil)
+ (allow-all nil :type boolean))
 
 (defvar gh-copilot-chat--instances (list)
   "Global instance of Copilot chat.")

--- a/gh-copilot-chat-responses.el
+++ b/gh-copilot-chat-responses.el
@@ -196,7 +196,8 @@ if the response should be added to history."
           (setf (gh-copilot-chat-responses-current-data responses) segment))
          ;; new event
          ((eq extracted 'event)
-          (setf (gh-copilot-chat-responses-event responses) (substring segment 7)))
+          (setf (gh-copilot-chat-responses-event responses)
+                (substring segment 7)))
          ;; Otherwise, JSON parsed successfully
          (extracted
           (gh-copilot-chat--responses-manage-data
@@ -208,7 +209,8 @@ Argument INSTANCE is the copilot chat instance to use.
 Argument PROMPT Copilot prompt to send (string or list of json objects)
 Argument NO-CONTEXT tells `gh-copilot-chat' to not send history and buffers."
   (let* ((create-req-fn
-          (gh-copilot-chat-frontend-create-req-fn (gh-copilot-chat--get-frontend)))
+          (gh-copilot-chat-frontend-create-req-fn
+           (gh-copilot-chat--get-frontend)))
          (copilot-instruction-content
           (and gh-copilot-chat-use-copilot-instruction-files
                (gh-copilot-chat--read-copilot-instructions-file)))
@@ -238,7 +240,8 @@ Argument NO-CONTEXT tells `gh-copilot-chat' to not send history and buffers."
     (unless no-context
       ;; Clean buffer list once and add buffer contents
       (setf (gh-copilot-chat-buffers instance)
-            (cl-remove-if-not #'buffer-live-p (gh-copilot-chat-buffers instance)))
+            (cl-remove-if-not
+             #'buffer-live-p (gh-copilot-chat-buffers instance)))
       (dolist (buffer (gh-copilot-chat-buffers instance))
         (setq messages
               (gh-copilot-chat--add-buffer-to-req buffer instance messages)))
@@ -298,16 +301,27 @@ Argument NO-CONTEXT tells `gh-copilot-chat' to not send history and buffers."
 INSTANCE is the copilot chat instance."
   (let ((results nil))
     (dolist (function functions)
-      (let* ((connection (gh-copilot-chat--mcp-find-connection instance function))
-             (name (gh-copilot-chat-function-name function))
-             (arguments (gh-copilot-chat-function-arguments function)))
-        (if (yes-or-no-p
-             (format
-              "Copilot Chat wants to call the tool '%s' with arguments: %s. Allow?"
-              name
-              (if (string-empty-p arguments)
-                  "none"
-                arguments)))
+      (let*
+          ((connection
+            (gh-copilot-chat--mcp-find-connection instance function))
+           (name (gh-copilot-chat-function-name function))
+           (arguments (gh-copilot-chat-function-arguments function))
+           (choice
+            (if (gh-copilot-chat-allow-all instance)
+                "all"
+              (read-answer
+               (format
+                "Copilot Chat wants to call the tool '%s' with arguments: %s. Allow?"
+                name
+                (if (string-empty-p arguments)
+                    "none"
+                  arguments))
+               '(("yes" ?y "allow this call")
+                 ("no" ?n "deny this call")
+                 ("all" ?! "allow all remaining calls"))))))
+        (when (string= choice "all")
+          (setf (gh-copilot-chat-allow-all instance) t))
+        (if (or (string= choice "yes") (string= choice "all"))
             (mcp-async-call-tool
              connection name
              (if (and arguments (not (string-empty-p arguments)))


### PR DESCRIPTION
- Introduced a new "allow all" option to streamline user interaction when approving multiple tool calls.
- Updated relevant functions to handle the new option and persist the choice within the chat instance.
- Enhanced user prompts to include the "allow all" option for better usability.

see #242