### PR TITLE
Claude code

### DIFF
--- a/gh-copilot-chat-claude.el
+++ b/gh-copilot-chat-claude.el
@@ -27,6 +27,8 @@
 
 ;;; Code:
 
+(defvar mcp-hub-servers)
+
 (defcustom gh-copilot-chat-claude-program "claude"
   "Claude program to use."
   :type 'string
@@ -46,6 +48,28 @@
  (current-data nil :type (or null string)))
 
 ;; functions
+(defun gh-copilot-chat--claude-mcp-config-arg (instance)
+  "Return --mcp-config JSON string for INSTANCE's MCP servers, or nil."
+  (when (and (bound-and-true-p mcp-hub-servers)
+             (gh-copilot-chat-mcp-servers instance))
+    (let ((servers-alist
+           (delq nil
+                 (mapcar
+                  (lambda (server-name)
+                    (let ((config (cdr (assoc server-name mcp-hub-servers))))
+                      (when config
+                        (let ((command (plist-get config :command))
+                              (args (plist-get config :args))
+                              (url (plist-get config :url)))
+                          (cons (intern server-name)
+                                (if url
+                                    `((url . ,url))
+                                  `((command . ,command)
+                                    (args . ,(vconcat args)))))))))
+                  (gh-copilot-chat-mcp-servers instance)))))
+      (when servers-alist
+        (json-encode `((mcpServers . ,servers-alist)))))))
+
 (defun gh-copilot-chat--claude-extract-segment (segment)
   "Extract data from an json string, returning one of:
 - `empty` if the segment has no data
@@ -170,6 +194,7 @@ if the prompt is out of context."
                      (eq (gh-copilot-chat-type instance) 'commit))
                 git-commit-instruction-content
               gh-copilot-chat-prompt)))
+         (mcp-config (gh-copilot-chat--claude-mcp-config-arg instance))
          (command
           (append
            (list
@@ -181,6 +206,8 @@ if the prompt is out of context."
              (list
               "--allowedTools"
               (concat "\"" gh-copilot-chat-claude-allowed-tools "\"")))
+           (when mcp-config
+             (list "--mcp-config" mcp-config))
            (when (and (not out-of-context)
                       (gh-copilot-chat-claude-session-id
                        (gh-copilot-chat--backend instance)))

--- a/gh-copilot-chat-claude.el
+++ b/gh-copilot-chat-claude.el
@@ -27,6 +27,12 @@
 
 ;;; Code:
 
+(require 'gh-copilot-chat-body)
+(require 'gh-copilot-chat-common)
+(require 'gh-copilot-chat-spinner)
+(require 'gh-copilot-chat-backend)
+(require 'gh-copilot-chat-mcp)
+
 (defvar mcp-hub-servers)
 
 (defcustom gh-copilot-chat-claude-program "claude"

--- a/gh-copilot-chat-claude.el
+++ b/gh-copilot-chat-claude.el
@@ -44,8 +44,23 @@
   :type 'boolean
   :group 'gh-copilot-chat)
 
-(defconst gh-copilot-chat-claude--sys-prompt
-  "IMPORTANT: Connected to Emacs via claude-code-ide.el integration. Emacs uses mixed coordinates: Lines: 1-based (line 1 = first line), Columns: 0-based (column 0 = first column). Example: First character in file is at line 1, column 0. Available: xref (LSP), tree-sitter, imenu, project.el, flycheck/flymake diagnostics. Context-aware with automatic project/file/selection tracking.")
+(defconst gh-copilot-chat-claude--builtin-tools
+  '("Bash"
+    "Edit"
+    "Write"
+    "Read"
+    "MultiEdit"
+    "WebSearch"
+    "WebFetch"
+    "TodoRead"
+    "TodoWrite"
+    "NotebookRead"
+    "NotebookEdit"
+    "LS"
+    "Glob"
+    "Grep"
+    "Task")
+  "Built-in Claude Code tools (fixed list).")
 
 ;; structures
 (cl-defstruct
@@ -53,9 +68,23 @@
  "Private data for Copilot chat claude backend."
  (process nil :type (or null process))
  (session-id nil :type (or null string))
- (current-data nil :type (or null string)))
+ (current-data nil :type (or null string))
+ (allowed-tools "" :type string))
 
 ;; functions
+
+(defun gh-copilot-chat-claude--tool-candidates (instance)
+  "Build tool completion candidates for INSTANCE.
+Combines built-in tools, MCP server wildcards, and IDE tools."
+  (append
+   gh-copilot-chat-claude--builtin-tools
+   (when (bound-and-true-p mcp-hub-servers)
+     (mapcar
+      (lambda (server-name) (format "mcp__%s__*" server-name))
+      (gh-copilot-chat-mcp-servers instance)))
+   (when (fboundp 'claude-code-ide-mcp-server-get-tool-names)
+     (claude-code-ide-mcp-server-get-tool-names "mcp__emacs-tools__"))))
+
 (defun gh-copilot-chat--claude-ide-setup (session-id)
   "Start claude-code-ide emacs-tools MCP server and register SESSION-ID.
 Returns the mcpServers alist entry (with SESSION-ID in the URL) on success,
@@ -217,7 +246,8 @@ if the prompt is out of context."
      (list :role "user" :content prompt) (gh-copilot-chat-history instance)))
 
   ;; start claude process
-  (let* ((copilot-instruction-content
+  (let* ((backend (gh-copilot-chat--backend instance))
+         (copilot-instruction-content
           (and gh-copilot-chat-use-copilot-instruction-files
                (gh-copilot-chat--read-copilot-instructions-file)))
          (formatted-copilot-instructions
@@ -242,31 +272,27 @@ if the prompt is out of context."
          (ide-servers
           (when ide-session-id
             (gh-copilot-chat--claude-ide-setup ide-session-id)))
-         (sse-project-dir
-          (when (and gh-copilot-chat-claude-use-ide-tools
-                     (featurep 'claude-code-ide-mcp)
-                     (fboundp 'claude-code-ide-mcp-start))
-            (or (when (fboundp 'project-root)
-                  (when-let ((proj (project-current)))
-                    (project-root proj)))
-                default-directory)))
          (mcp-config
           (gh-copilot-chat--claude-mcp-config-arg instance ide-servers))
          (all-allowed-tools
-          (let ((parts
-                 (delq
-                  nil
-                  (list
-                   "Edit Write Read"
-                   (unless (string-empty-p gh-copilot-chat-claude-allowed-tools)
-                     gh-copilot-chat-claude-allowed-tools)
-                   (when (and ide-servers
-                              (fboundp
-                               'claude-code-ide-mcp-server-get-tool-names))
-                     (mapconcat #'identity
-                                (claude-code-ide-mcp-server-get-tool-names
-                                 "mcp__emacs-tools__")
-                                " "))))))
+          (let* ((allowed (gh-copilot-chat-claude-allowed-tools backend))
+                 (parts
+                  (delq
+                   nil
+                   (list
+                    "Edit Write Read"
+                    (unless (string-empty-p
+                             gh-copilot-chat-claude-allowed-tools)
+                      gh-copilot-chat-claude-allowed-tools)
+                    (unless (string-empty-p allowed)
+                      allowed)
+                    (when (and ide-servers
+                               (fboundp
+                                'claude-code-ide-mcp-server-get-tool-names))
+                      (mapconcat #'identity
+                                 (claude-code-ide-mcp-server-get-tool-names
+                                  "mcp__emacs-tools__")
+                                 " "))))))
             (when parts
               (string-join parts " "))))
          (command
@@ -275,9 +301,7 @@ if the prompt is out of context."
             gh-copilot-chat-claude-program
             "--print"
             "--verbose"
-            "--output-format=stream-json"
-            "--append-system-prompt"
-            gh-copilot-chat-claude--sys-prompt)
+            "--output-format=stream-json")
            (when all-allowed-tools
              (list "--allowedTools" all-allowed-tools))
            (when mcp-config
@@ -289,9 +313,9 @@ if the prompt is out of context."
               "--resume"
               (gh-copilot-chat-claude-session-id
                (gh-copilot-chat--backend instance))))
-           (list prompt)
            (when instructions
-             (list "--system-prompt" instructions)))))
+             (list "--system-prompt" instructions))
+           (list prompt))))
     (setf (gh-copilot-chat-claude-process (gh-copilot-chat--backend instance))
           (make-process
            :name "gh-copilot-chat-claude"
@@ -333,6 +357,35 @@ if the prompt is out of context."
     (delete-process
      (gh-copilot-chat-claude-process (gh-copilot-chat--backend instance))))
   (gh-copilot-chat--spinner-stop instance))
+
+;;;###autoload
+(defun gh-copilot-chat-claude-set-allowed-tools ()
+  "Interactively set extra allowed tools for the current Claude session.
+The tools selected here are added on top of the always-allowed
+\"Edit Write Read\" and the global `gh-copilot-chat-claude-allowed-tools'."
+  (interactive)
+  (let* ((instance (gh-copilot-chat--current-instance))
+         (backend (gh-copilot-chat--backend instance)))
+    (unless (gh-copilot-chat-claude-p backend)
+      (user-error "Current backend is not Claude"))
+    (let* ((current (gh-copilot-chat-claude-allowed-tools backend))
+           (current-list (split-string current " " t))
+           (selected
+            (completing-read-multiple
+             (format "Allowed tools [current: %s]: "
+                     (if current-list
+                         (string-join current-list ", ")
+                       "none"))
+             (gh-copilot-chat-claude--tool-candidates instance) nil
+             nil ;; require-match = nil
+             (string-join current-list ","))))
+      (setf (gh-copilot-chat-claude-allowed-tools backend)
+            (string-join selected " "))
+      (message "Session allowed tools: %s"
+               (if selected
+                   (string-join selected " ")
+                 "(none)")))))
+
 
 ;; Top-level execute code.
 (cl-pushnew

--- a/gh-copilot-chat-claude.el
+++ b/gh-copilot-chat-claude.el
@@ -39,6 +39,14 @@
   :type 'string
   :group 'gh-copilot-chat)
 
+(defcustom gh-copilot-chat-claude-use-ide-tools t
+  "When non-nil, expose claude-code-ide emacs-tools via MCP if the package is loaded."
+  :type 'boolean
+  :group 'gh-copilot-chat)
+
+(defconst gh-copilot-chat-claude--sys-prompt
+  "IMPORTANT: Connected to Emacs via claude-code-ide.el integration. Emacs uses mixed coordinates: Lines: 1-based (line 1 = first line), Columns: 0-based (column 0 = first column). Example: First character in file is at line 1, column 0. Available: xref (LSP), tree-sitter, imenu, project.el, flycheck/flymake diagnostics. Context-aware with automatic project/file/selection tracking.")
+
 ;; structures
 (cl-defstruct
  gh-copilot-chat-claude
@@ -48,27 +56,52 @@
  (current-data nil :type (or null string)))
 
 ;; functions
-(defun gh-copilot-chat--claude-mcp-config-arg (instance)
-  "Return --mcp-config JSON string for INSTANCE's MCP servers, or nil."
-  (when (and (bound-and-true-p mcp-hub-servers)
-             (gh-copilot-chat-mcp-servers instance))
-    (let ((servers-alist
-           (delq nil
-                 (mapcar
-                  (lambda (server-name)
-                    (let ((config (cdr (assoc server-name mcp-hub-servers))))
-                      (when config
-                        (let ((command (plist-get config :command))
-                              (args (plist-get config :args))
-                              (url (plist-get config :url)))
-                          (cons (intern server-name)
-                                (if url
-                                    `((url . ,url))
-                                  `((command . ,command)
-                                    (args . ,(vconcat args)))))))))
-                  (gh-copilot-chat-mcp-servers instance)))))
-      (when servers-alist
-        (json-encode `((mcpServers . ,servers-alist)))))))
+(defun gh-copilot-chat--claude-ide-setup (session-id)
+  "Start claude-code-ide emacs-tools MCP server and register SESSION-ID.
+Returns the mcpServers alist entry (with SESSION-ID in the URL) on success,
+nil if the package is not loaded or the server fails to start."
+  (when (and gh-copilot-chat-claude-use-ide-tools
+             (featurep 'claude-code-ide-emacs-tools)
+             (fboundp 'claude-code-ide-emacs-tools-setup)
+             (fboundp 'claude-code-ide-mcp-server-ensure-server)
+             (fboundp 'claude-code-ide-mcp-server-get-config)
+             (fboundp 'claude-code-ide-mcp-server-session-started))
+    (claude-code-ide-emacs-tools-setup)
+    (when (claude-code-ide-mcp-server-ensure-server)
+      (let* ((project-dir
+              (or (when (fboundp 'project-root)
+                    (when-let* ((proj (project-current)))
+                      (project-root proj)))
+                  default-directory))
+             (buffer (current-buffer)))
+        (claude-code-ide-mcp-server-session-started
+         session-id project-dir buffer)
+        (alist-get
+         'mcpServers (claude-code-ide-mcp-server-get-config session-id))))))
+
+(defun gh-copilot-chat--claude-mcp-config-arg (instance &optional ide-servers)
+  "Return --mcp-config JSON string for INSTANCE's MCP servers, or nil.
+IDE-SERVERS is an optional mcpServers alist from claude-code-ide to merge in."
+  (let* ((hub-servers
+          (when (and (bound-and-true-p mcp-hub-servers)
+                     (gh-copilot-chat-mcp-servers instance))
+            (delq
+             nil
+             (mapcar
+              (lambda (server-name)
+                (when-let* ((config (cdr (assoc server-name mcp-hub-servers))))
+                  (let ((command (plist-get config :command))
+                        (args (plist-get config :args))
+                        (url (plist-get config :url)))
+                    (cons
+                     (intern server-name)
+                     (if url
+                         `((url . ,url))
+                       `((command . ,command) (args . ,(vconcat args))))))))
+              (gh-copilot-chat-mcp-servers instance)))))
+         (all-servers (append hub-servers ide-servers)))
+    (when all-servers
+      (json-encode `((mcpServers . ,all-servers))))))
 
 (defun gh-copilot-chat--claude-extract-segment (segment)
   "Extract data from an json string, returning one of:
@@ -180,8 +213,8 @@ if the prompt is out of context."
   ;; The Claude backend relies on --resume for context, so only
   ;; user prompts are stored here (not assistant answers).
   (unless out-of-context
-    (push (list :role "user" :content prompt)
-          (gh-copilot-chat-history instance)))
+    (push
+     (list :role "user" :content prompt) (gh-copilot-chat-history instance)))
 
   ;; start claude process
   (let* ((copilot-instruction-content
@@ -201,18 +234,52 @@ if the prompt is out of context."
                      (eq (gh-copilot-chat-type instance) 'commit))
                 git-commit-instruction-content
               gh-copilot-chat-prompt)))
-         (mcp-config (gh-copilot-chat--claude-mcp-config-arg instance))
+         (ide-session-id
+          (when (and gh-copilot-chat-claude-use-ide-tools
+                     (featurep 'claude-code-ide-emacs-tools))
+            (format "gh-copilot-chat-%s"
+                    (format-time-string "%Y%m%d-%H%M%S%3N"))))
+         (ide-servers
+          (when ide-session-id
+            (gh-copilot-chat--claude-ide-setup ide-session-id)))
+         (sse-project-dir
+          (when (and gh-copilot-chat-claude-use-ide-tools
+                     (featurep 'claude-code-ide-mcp)
+                     (fboundp 'claude-code-ide-mcp-start))
+            (or (when (fboundp 'project-root)
+                  (when-let ((proj (project-current)))
+                    (project-root proj)))
+                default-directory)))
+         (mcp-config
+          (gh-copilot-chat--claude-mcp-config-arg instance ide-servers))
+         (all-allowed-tools
+          (let ((parts
+                 (delq
+                  nil
+                  (list
+                   "Edit Write Read"
+                   (unless (string-empty-p gh-copilot-chat-claude-allowed-tools)
+                     gh-copilot-chat-claude-allowed-tools)
+                   (when (and ide-servers
+                              (fboundp
+                               'claude-code-ide-mcp-server-get-tool-names))
+                     (mapconcat #'identity
+                                (claude-code-ide-mcp-server-get-tool-names
+                                 "mcp__emacs-tools__")
+                                " "))))))
+            (when parts
+              (string-join parts " "))))
          (command
           (append
            (list
             gh-copilot-chat-claude-program
             "--print"
             "--verbose"
-            "--output-format=stream-json")
-           (unless (string-empty-p gh-copilot-chat-claude-allowed-tools)
-             (list
-              "--allowedTools"
-              (concat "\"" gh-copilot-chat-claude-allowed-tools "\"")))
+            "--output-format=stream-json"
+            "--append-system-prompt"
+            gh-copilot-chat-claude--sys-prompt)
+           (when all-allowed-tools
+             (list "--allowedTools" all-allowed-tools))
            (when mcp-config
              (list "--mcp-config" mcp-config))
            (when (and (not out-of-context)
@@ -222,9 +289,9 @@ if the prompt is out of context."
               "--resume"
               (gh-copilot-chat-claude-session-id
                (gh-copilot-chat--backend instance))))
-           (list (concat "\"" prompt "\""))
+           (list prompt)
            (when instructions
-             (list "--system-prompt" (concat "\"" instructions "\""))))))
+             (list "--system-prompt" instructions)))))
     (setf (gh-copilot-chat-claude-process (gh-copilot-chat--backend instance))
           (make-process
            :name "gh-copilot-chat-claude"
@@ -246,6 +313,10 @@ if the prompt is out of context."
              (setf (gh-copilot-chat-claude-process
                     (gh-copilot-chat--backend instance))
                    nil)
+             (when (and ide-servers
+                        ide-session-id
+                        (fboundp 'claude-code-ide-mcp-server-session-ended))
+               (claude-code-ide-mcp-server-session-ended ide-session-id))
              (gh-copilot-chat--spinner-stop instance))
            :stderr (get-buffer-create "*gh-copilot-chat-claude-stderr*")
            :command command))))

--- a/gh-copilot-chat-claude.el
+++ b/gh-copilot-chat-claude.el
@@ -1,0 +1,252 @@
+;;; gh-copilot-chat --- gh-copilot-chat-claude.el --- copilot chat claude backend -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024  gh-copilot-chat maintainers
+
+;; The MIT License (MIT)
+
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to deal
+;; in the Software without restriction, including without limitation the rights
+;; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;; copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+;;; Commentary:
+;; This is claude backend for gh-copilot-chat code
+
+;;; Code:
+
+(defcustom gh-copilot-chat-claude-program "claude"
+  "Claude program to use."
+  :type 'string
+  :group 'gh-copilot-chat)
+
+(defcustom gh-copilot-chat-claude-allowed-tools ""
+  "Claude allowed tools, see --allowedTools."
+  :type 'string
+  :group 'gh-copilot-chat)
+
+;; structures
+(cl-defstruct
+ gh-copilot-chat-claude
+ "Private data for Copilot chat claude backend."
+ (process nil :type (or null process))
+ (session-id nil :type (or null string))
+ (current-data nil :type (or null string)))
+
+;; functions
+(defun gh-copilot-chat--claude-extract-segment (segment)
+  "Extract data from an json string, returning one of:
+- `empty` if the segment has no data
+- `partial`: if the segment seems to be incomplete, i.e. more data in a
+  future response
+- otherwise, the entire JSON content (data: {...})
+Argument SEGMENT is data segment to parse."
+  (cond
+   ;; empty
+   ((string-empty-p segment)
+    'empty)
+   ((string-prefix-p "event:" segment)
+    'event)
+   ((string-prefix-p "data: " segment)
+    (let ((data (substring segment 6)))
+      (condition-case _err
+          (json-parse-string data :object-type 'alist :false-object :json-false)
+        ;; failure => the segment was probably truncated and we need more data from a future
+        ;; response
+        (json-parse-error
+         'partial)
+        (json-end-of-file
+         'partial))))
+   (t
+    (condition-case _err
+        (json-parse-string segment
+                           :object-type 'alist
+                           :false-object
+                           :json-false)
+      (error
+       'partial)))))
+
+(defun gh-copilot-chat--claude-manage-data
+    (instance claude-struct callback out-of-context data)
+  "Manage DATA from claude stream-json output.
+Argument INSTANCE is the copilot chat instance to use.
+Argument CLAUDE-STRUCT is the copilot chat claude data.
+Argument CALLBACK is the function to call with analysed data.
+Argument OUT-OF-CONTEXT is a boolean to indicate
+if the prompt is out of context."
+  (let ((type (alist-get 'type data)))
+    (cond
+     ;; Save session ID from init message for future --resume
+     ((string= type "system")
+      (when (string= (alist-get 'subtype data) "init")
+        (setf (gh-copilot-chat-claude-session-id claude-struct)
+              (alist-get 'session_id data))))
+
+     ;; Extract text chunks from assistant messages
+     ((string= type "assistant")
+      (gh-copilot-chat--spinner-set-status instance "Generating")
+      (let* ((message (alist-get 'message data))
+             (content (alist-get 'content message)))
+        (seq-do
+         (lambda (item)
+           (when (string= (alist-get 'type item) "text")
+             (funcall callback instance (alist-get 'text item))))
+         content)))
+
+     ;; End of response: send magic to signal completion
+     ((string= type "result")
+      (setf (gh-copilot-chat-claude-session-id claude-struct)
+            (alist-get 'session_id data))
+      (when (string= (alist-get 'subtype data) "error")
+        (funcall callback instance (alist-get 'result data)))
+      (funcall callback instance gh-copilot-chat--magic)))))
+
+(defun gh-copilot-chat--claude-analyze-answer
+    (instance data callback out-of-context)
+  "Argument INSTANCE is the copilot chat instance to use.
+Argument DATA is the string returned by the claude process.
+Argument CALLBACK is the function to call with analysed data.
+Argument OUT-OF-CONTEXT is a boolean to indicate
+if the prompt is out of context."
+  (let* ((claude (gh-copilot-chat--backend instance))
+         (current-data (gh-copilot-chat-claude-current-data claude))
+         (full-data
+          (if current-data
+              (concat current-data data)
+            data))
+         (lines (split-string full-data "\n")))
+    (setf (gh-copilot-chat-claude-current-data claude) nil)
+    ;; All lines except the last are complete JSON objects; the last may be partial
+    (dolist (line (butlast lines))
+      (let ((extracted (gh-copilot-chat--claude-extract-segment line)))
+        (when (and extracted (not (memq extracted '(empty event partial))))
+          (gh-copilot-chat--claude-manage-data
+           instance claude callback out-of-context extracted))))
+    ;; Save the last line if non-empty (it may be a partial JSON object)
+    (let ((last-line (car (last lines))))
+      (when (and last-line (not (string-empty-p last-line)))
+        (setf (gh-copilot-chat-claude-current-data claude) last-line)))))
+
+;; functions
+(defun gh-copilot-chat--claude-ask (instance prompt callback out-of-context)
+  "Ask a question to Copilot using claude backend.
+Argument INSTANCE is the copilot chat instance to use.
+Argument PROMPT is the prompt to send to copilot.  It can be a string or a list
+of json objects.
+Argument CALLBACK is the function to call with copilot answer as argument.
+Argument OUT-OF-CONTEXT is a boolean to indicate
+if the prompt is out of context."
+  ;; Start the spinner animation only for instances with chat buffers
+  (when (buffer-live-p (gh-copilot-chat-chat-buffer instance))
+    (gh-copilot-chat--spinner-start instance))
+
+  ;; start claude process
+  (let* ((copilot-instruction-content
+          (and gh-copilot-chat-use-copilot-instruction-files
+               (gh-copilot-chat--read-copilot-instructions-file)))
+         (formatted-copilot-instructions
+          (and copilot-instruction-content
+               (gh-copilot-chat--format-copilot-instructions
+                copilot-instruction-content)))
+         (git-commit-instruction-content
+          (and gh-copilot-chat-use-git-commit-instruction-files
+               (gh-copilot-chat--read-git-commit-instructions-file)))
+         (instructions
+          (if formatted-copilot-instructions
+              formatted-copilot-instructions
+            (if (and git-commit-instruction-content
+                     (eq (gh-copilot-chat-type instance) 'commit))
+                git-commit-instruction-content
+              gh-copilot-chat-prompt)))
+         (command
+          (append
+           (list
+            gh-copilot-chat-claude-program
+            "--print"
+            "--verbose"
+            "--output-format=stream-json")
+           (unless (string-empty-p gh-copilot-chat-claude-allowed-tools)
+             (list
+              "--allowedTools"
+              (concat "\"" gh-copilot-chat-claude-allowed-tools "\"")))
+           (when (and (not out-of-context)
+                      (gh-copilot-chat-claude-session-id
+                       (gh-copilot-chat--backend instance)))
+             (list
+              "--resume"
+              (gh-copilot-chat-claude-session-id
+               (gh-copilot-chat--backend instance))))
+           (list (concat "\"" prompt "\""))
+           (when instructions
+             (list "--system-prompt" (concat "\"" instructions "\""))))))
+    (setf (gh-copilot-chat-claude-process (gh-copilot-chat--backend instance))
+          (make-process
+           :name "gh-copilot-chat-claude"
+           :buffer nil
+           :filter
+           (lambda (proc string)
+             (gh-copilot-chat--debug
+              'curl "gh-copilot-chat--claude-ask: %s" string)
+             (gh-copilot-chat--claude-analyze-answer
+              instance string callback out-of-context))
+           :sentinel
+           (lambda (proc _exit)
+             (when (/= (process-exit-status proc) 0)
+               (let ((error-msg
+                      (format "Claude interrupted: %d"
+                              (process-exit-status proc))))
+                 (funcall callback instance error-msg)
+                 (funcall callback instance gh-copilot-chat--magic)))
+             (setf (gh-copilot-chat-claude-process
+                    (gh-copilot-chat--backend instance))
+                   nil)
+             (gh-copilot-chat--spinner-stop instance))
+           :stderr (get-buffer-create "*gh-copilot-chat-claude-stderr*")
+           :command command))))
+
+
+(defun gh-copilot-chat--claude-init (instance)
+  "Initialize Copilot chat claude backend for INSTANCE."
+  (setf (gh-copilot-chat--backend instance) (make-gh-copilot-chat-claude)))
+
+(defun gh-copilot-chat--claude-cancel (instance)
+  "Cancel Copilot chat claude backend for INSTANCE."
+  (when (process-live-p
+         (gh-copilot-chat-claude-process (gh-copilot-chat--backend instance)))
+    (delete-process
+     (gh-copilot-chat-claude-process (gh-copilot-chat--backend instance))))
+  (gh-copilot-chat--spinner-stop instance))
+
+;; Top-level execute code.
+(cl-pushnew
+ (make-gh-copilot-chat-backend
+  :id 'claude
+  :init-fn #'gh-copilot-chat--claude-init
+  :clean-fn nil
+  :login-fn nil
+  :renew-token-fn nil
+  :ask-fn #'gh-copilot-chat--claude-ask
+  :cancel-fn #'gh-copilot-chat--claude-cancel
+  :quotas-fn nil)
+ gh-copilot-chat--backend-list
+ :test #'equal)
+
+(provide 'gh-copilot-chat-claude)
+;;; gh-copilot-chat-claude.el ends here
+
+;; Local Variables:
+;; byte-compile-warnings: (not obsolete)
+;; fill-column: 80
+;; End:

--- a/gh-copilot-chat-claude.el
+++ b/gh-copilot-chat-claude.el
@@ -176,6 +176,13 @@ if the prompt is out of context."
   (when (buffer-live-p (gh-copilot-chat-chat-buffer instance))
     (gh-copilot-chat--spinner-start instance))
 
+  ;; Record prompt in history for navigation (M-p / M-n).
+  ;; The Claude backend relies on --resume for context, so only
+  ;; user prompts are stored here (not assistant answers).
+  (unless out-of-context
+    (push (list :role "user" :content prompt)
+          (gh-copilot-chat-history instance)))
+
   ;; start claude process
   (let* ((copilot-instruction-content
           (and gh-copilot-chat-use-copilot-instruction-files

--- a/gh-copilot-chat-claude.el
+++ b/gh-copilot-chat-claude.el
@@ -40,7 +40,7 @@
   :type 'string
   :group 'gh-copilot-chat)
 
-(defcustom gh-copilot-chat-claude-allowed-tools ""
+(defcustom gh-copilot-chat-claude-allowed-tools "Edit Write Read"
   "Claude allowed tools, see --allowedTools."
   :type 'string
   :group 'gh-copilot-chat)
@@ -286,7 +286,6 @@ if the prompt is out of context."
                   (delq
                    nil
                    (list
-                    "Edit Write Read"
                     (unless (string-empty-p
                              gh-copilot-chat-claude-allowed-tools)
                       gh-copilot-chat-claude-allowed-tools)
@@ -378,7 +377,8 @@ The tools selected here are added on top of the always-allowed
            (current-list (split-string current " " t))
            (selected
             (completing-read-multiple
-             (format "Allowed tools [current: %s]: "
+             (format "Allowed tools [global: %s] [current: %s]: "
+                     gh-copilot-chat-claude-allowed-tools
                      (if current-list
                          (string-join current-list ", ")
                        "none"))

--- a/gh-copilot-chat-claude.el
+++ b/gh-copilot-chat-claude.el
@@ -203,6 +203,8 @@ if the prompt is out of context."
             (alist-get 'session_id data))
       (when (string= (alist-get 'subtype data) "error")
         (funcall callback instance (alist-get 'result data)))
+      (let ((hist `(:content ,(alist-get 'result data) :role "assistant")))
+        (push hist (gh-copilot-chat-history instance)))
       (funcall callback instance gh-copilot-chat--magic)))))
 
 (defun gh-copilot-chat--claude-analyze-answer
@@ -245,8 +247,6 @@ if the prompt is out of context."
     (gh-copilot-chat--spinner-start instance))
 
   ;; Record prompt in history for navigation (M-p / M-n).
-  ;; The Claude backend relies on --resume for context, so only
-  ;; user prompts are stored here (not assistant answers).
   (unless out-of-context
     (push
      (list :role "user" :content prompt) (gh-copilot-chat-history instance)))

--- a/gh-copilot-chat-copilot.el
+++ b/gh-copilot-chat-copilot.el
@@ -207,10 +207,8 @@ Optional argument TYPE is the type of the instance (nil or commit)."
   "Login to GitHub Copilot API."
   (let ((login-fn
          (gh-copilot-chat-backend-login-fn (gh-copilot-chat--get-backend))))
-    (if login-fn
-        (funcall login-fn)
-      (error "No login function for backend: %s"
-             (gh-copilot-chat--get-backend)))))
+    (when login-fn
+      (funcall login-fn))))
 
 
 (defun gh-copilot-chat--renew-token ()
@@ -227,39 +225,47 @@ Optional argument TYPE is the type of the instance (nil or commit)."
   "Authenticate with GitHub Copilot API.
 We first need github authorization (github token).
 Then we need a session token."
-  (unless (gh-copilot-chat-connection-github-token gh-copilot-chat--connection)
-    (let ((token (gh-copilot-chat--get-cached-token)))
-      (if token
-          (setf (gh-copilot-chat-connection-github-token
-                 gh-copilot-chat--connection)
-                token)
-        (gh-copilot-chat--login))))
-
-  (when (null (gh-copilot-chat-connection-token gh-copilot-chat--connection))
-    ;; try to load token from ~/.cache/gh-copilot-chat-token
-    (let ((token-file (expand-file-name gh-copilot-chat-token-cache)))
-      (when (file-exists-p token-file)
-        (with-temp-buffer
-          (insert-file-contents token-file)
-          (let ((token
-                 (json-read-from-string
-                  (buffer-substring-no-properties (point-min) (point-max)))))
-            (if (string= "Bad credentials" (alist-get 'message token))
-                (gh-copilot-chat--login)
-              (setf (gh-copilot-chat-connection-token
+  (let ((login-fn
+         (gh-copilot-chat-backend-login-fn (gh-copilot-chat--get-backend))))
+    (when login-fn
+      (unless (gh-copilot-chat-connection-github-token
+               gh-copilot-chat--connection)
+        (let ((token (gh-copilot-chat--get-cached-token)))
+          (if token
+              (setf (gh-copilot-chat-connection-github-token
                      gh-copilot-chat--connection)
-                    token)))))))
+                    token)
+            (gh-copilot-chat--login))))
 
-  (when (let* ((token
-                (gh-copilot-chat-connection-token gh-copilot-chat--connection))
-               (expires-at (and (listp token) (alist-get 'expires_at token)))
-               (now (round (float-time (current-time)))))
-          ;; Renew token if missing, malformed, or expired.
-          (or (null token)
-              (null expires-at)
-              (and (numberp expires-at) (> now expires-at))))
-    (gh-copilot-chat--renew-token))
-  (setf (gh-copilot-chat-connection-ready gh-copilot-chat--connection) t))
+      (when (null
+             (gh-copilot-chat-connection-token gh-copilot-chat--connection))
+        ;; try to load token from ~/.cache/gh-copilot-chat-token
+        (let ((token-file (expand-file-name gh-copilot-chat-token-cache)))
+          (when (file-exists-p token-file)
+            (with-temp-buffer
+              (insert-file-contents token-file)
+              (let ((token
+                     (json-read-from-string
+                      (buffer-substring-no-properties
+                       (point-min) (point-max)))))
+                (if (string= "Bad credentials" (alist-get 'message token))
+                    (gh-copilot-chat--login)
+                  (setf (gh-copilot-chat-connection-token
+                         gh-copilot-chat--connection)
+                        token)))))))
+
+      (when (let* ((token
+                    (gh-copilot-chat-connection-token
+                     gh-copilot-chat--connection))
+                   (expires-at
+                    (and (listp token) (alist-get 'expires_at token)))
+                   (now (round (float-time (current-time)))))
+              ;; Renew token if missing, malformed, or expired.
+              (or (null token)
+                  (null expires-at)
+                  (and (numberp expires-at) (> now expires-at))))
+        (gh-copilot-chat--renew-token))
+      (setf (gh-copilot-chat-connection-ready gh-copilot-chat--connection) t))))
 
 (defun gh-copilot-chat--ask (instance prompt callback &optional out-of-context)
   "Ask a question to Copilot.

--- a/gh-copilot-chat.el
+++ b/gh-copilot-chat.el
@@ -75,7 +75,8 @@
   (lambda (symbol value)
     (set-default-toplevel-value symbol value)
     (pcase value
-      (`curl (require 'gh-copilot-chat-curl))))
+      (`curl (require 'gh-copilot-chat-curl))
+      (`claude (require 'gh-copilot-chat-claude))))
   :group 'gh-copilot-chat)
 
 (provide 'gh-copilot-chat)

--- a/readme.org
+++ b/readme.org
@@ -13,6 +13,12 @@ This plugin allows you to chat with GitHub copilot.
 Feel free to contribute, report issues or discuss new features.
 
 * News
+** Claude Code backend
+A new ~claude~ backend is available, powered by the [[https://docs.anthropic.com/en/docs/claude-code][Claude Code CLI]].
+It does not require a GitHub account and brings several advantages: native MCP support,
+session resumption, Emacs IDE tools integration, and per-session tool authorization.
+See the [[*Claude backend][Claude backend]] section for configuration details.
+
 ** Repository renaming
 ~copilot-chat~ has been renamed ~gh-copilot-chat~ to avoid conflicts with ~copilot.el~.
 Everything is the same, functions and variable just have the ~gh-~ prefix.
@@ -72,6 +78,24 @@ Calling ~gh-copilot-chat-display~ with prefix argument will let you choose insta
 ** Save instance
 You can use ~gh-copilot-chat-save~ and ~gh-copilot-chat-load~ to save/restore a chat with its history.
 
+** Session tool permissions (Claude backend)
+When using the ~claude~ backend, Claude Code may need specific tools to fulfill a request
+(e.g. ~WebFetch~ to browse a URL, ~Bash~ to run a command). You can grant extra tools
+for the current session without restarting, using ~gh-copilot-chat-claude-set-allowed-tools~.
+
+It opens a ~completing-read-multiple~ prompt pre-filled with already-allowed tools.
+The candidates are built dynamically from built-in Claude tools, active MCP server wildcards
+(e.g. ~mcp__github__*~), and Emacs IDE tools. Free text is also accepted for any tool not in the list.
+
+#+begin_src emacs-lisp
+;; Example: bind it for quick access in the chat buffer
+(define-key gh-copilot-chat-prompt-mode-map
+  (kbd "C-c C-a") #'gh-copilot-chat-claude-set-allowed-tools)
+#+end_src
+
+Tools granted this way apply only to the current session and are combined with the
+always-allowed ~Edit Write Read~ defaults and the global ~gh-copilot-chat-claude-allowed-tools~.
+
 * Installation
 ** Melpa
 Copilot-chat is available on melpa :
@@ -106,7 +130,9 @@ You will need a GitHub account with access to copilot API. When sending the firs
 With curl, answers will be written token by token. Curl path can be set with the ~gh-copilot-chat-curl-program~ variable.
 
 *** Claude backend
-The ~claude~ backend uses the [[https://docs.anthropic.com/en/docs/claude-code][Claude CLI]] instead of the GitHub Copilot API. It does not require a GitHub account - authentication is handled by the Claude CLI itself.
+The ~claude~ backend uses the [[https://docs.anthropic.com/en/docs/claude-code][Claude CLI]] instead of the GitHub Copilot API. It
+does not require a GitHub account - authentication is handled by the Claude CLI
+itself.
 
 **** Prerequisites
 - Install the Claude CLI and make sure it is available in your PATH. See [[https://docs.anthropic.com/en/docs/claude-code/getting-started][Getting started with Claude Code]].
@@ -125,11 +151,17 @@ Or with ~use-package~:
 #+end_src
 
 **** Allowed tools
-By default, no tools are passed to the Claude CLI. You can allow specific built-in tools using the ~gh-copilot-chat-claude-allowed-tools~ variable (maps to ~--allowedTools~):
+By default, ~Edit~, ~Write~ and ~Read~ are always passed to the Claude CLI.
+You can persistently allow additional built-in tools using the
+~gh-copilot-chat-claude-allowed-tools~ variable (maps to ~--allowedTools~).
+Tool names are space-separated:
 #+begin_src emacs-lisp
-;; Example: allow bash and file editing tools
-(setq gh-copilot-chat-claude-allowed-tools "Bash,Edit,Write")
+;; Example: also allow Bash and web access globally
+(setq gh-copilot-chat-claude-allowed-tools "Bash WebFetch WebSearch")
 #+end_src
+
+To grant tools for a single session only (without changing your config), use
+~gh-copilot-chat-claude-set-allowed-tools~. See the [[*Session tool permissions (Claude backend)][Session tool permissions]] tip.
 
 **** MCP servers
 When MCP servers are configured via ~mcp-hub-servers~ and enabled for a ~gh-copilot-chat~ instance (using ~gh-copilot-chat-set-mcp-servers~), they are automatically passed to the Claude CLI via ~--mcp-config~. This allows Claude to use your MCP tools directly.
@@ -148,6 +180,15 @@ Example with a GitHub MCP server:
 #+end_src
 
 Then enable the server for your instance with ~gh-copilot-chat-set-mcp-servers~.
+
+**** Emacs IDE tools integration
+When the ~claude-code-ide-emacs-tools~ package is loaded, the Claude backend can
+automatically expose Emacs IDE tools (xref, imenu, project info…) to Claude Code via MCP.
+This is controlled by the ~gh-copilot-chat-claude-use-ide-tools~ variable (default: ~t~):
+#+begin_src emacs-lisp
+;; Disable IDE tools integration
+(setq gh-copilot-chat-claude-use-ide-tools nil)
+#+end_src
 
 **** Session resumption
 The Claude backend automatically resumes the conversation session between prompts using ~--resume~. This means the full conversation context is preserved inside the Claude CLI process, without being re-sent to the API on each turn.
@@ -212,6 +253,9 @@ You can call ~(gh-copilot-chat-transient)~ to open transient menu. Almost all fu
 *** MCP servers
 - ~(gh-copilot-chat-set-mcp-servers)~ open MCP server menu.
 
+*** Claude backend
+- ~(gh-copilot-chat-claude-set-allowed-tools)~ interactively set extra allowed tools for the current Claude session. Uses ~completing-read-multiple~ with candidates built from built-in tools, active MCP server wildcards, and Emacs IDE tools. Free text input is accepted. Changes apply only to the current session.
+
 *** Answer manipulation
 - ~(gh-copilot-chat-yank)~ yank the last code block at point (org frontend only).
 - ~(gh-copilot-chat-yank-pop)~ Replace last yank with previous block, or use argument to choose the block. Acts like ~(yank-pop)~ (org frontend only).
@@ -250,7 +294,6 @@ You can call ~(gh-copilot-chat-transient)~ to open transient menu. Almost all fu
 - ~(gh-copilot-chat-transient)~ display main transient menu to access all functions.
 - ~(gh-copilot-chat-transient-buffers)~ display transient menu for buffer management.
 - ~(gh-copilot-chat-transient-code)~ display transient menu for code helper functions.
-- ~(gh-copilot-chat-transient-magit)~ display transient menu for magit functions.
 
 *** Troubleshooting
 - ~(gh-copilot-chat-quotas)~ display GitHub copilot current quotas.
@@ -270,7 +313,8 @@ All variables can be customized using ~M-x customize-group RET gh-copilot-chat R
 - ~gh-copilot-chat-curl-proxy-insecure~ - Skip SSL verification for proxy connections in curl backend.
 - ~gh-copilot-chat-curl-proxy-user-pass~ - Proxy authentication credentials for curl backend.
 - ~gh-copilot-chat-claude-program~ - Path to the ~claude~ CLI executable (default: ~"claude"~). Set this if ~claude~ is not in your PATH.
-- ~gh-copilot-chat-claude-allowed-tools~ - Comma-separated list of tools allowed for the Claude CLI (maps to ~--allowedTools~). Empty by default (no tools allowed).
+- ~gh-copilot-chat-claude-allowed-tools~ - Space-separated list of tools persistently allowed for the Claude CLI (maps to ~--allowedTools~). Empty by default. ~Edit~, ~Write~ and ~Read~ are always allowed regardless of this setting.
+- ~gh-copilot-chat-claude-use-ide-tools~ - When non-nil (default), expose Emacs IDE tools (xref, imenu, project…) to Claude Code via MCP if the ~claude-code-ide-emacs-tools~ package is loaded.
 
 *** Frontend
 - ~gh-copilot-chat-frontend~ - Frontend interface to use. Can be ~'org~ (default) or ~'markdown~.

--- a/readme.org
+++ b/readme.org
@@ -101,9 +101,56 @@ Clone repository and eval files in Emacs.
 You will need a GitHub account with access to copilot API. When sending the first prompt, you will need to authenticate to GitHub. Follow instructions and everything will be fine.
 
 ** Backend
-~gh-copilot-chat-backend~ can only be set to ~'curl~.
+~gh-copilot-chat-backend~ can be set to ~'curl~ (default) or ~'claude~.
 
-With curl, answers will be written token by token. Curl path can be set with the `gh-copilot-chat-curl-program` variable.
+With curl, answers will be written token by token. Curl path can be set with the ~gh-copilot-chat-curl-program~ variable.
+
+*** Claude backend
+The ~claude~ backend uses the [[https://docs.anthropic.com/en/docs/claude-code][Claude CLI]] instead of the GitHub Copilot API. It does not require a GitHub account - authentication is handled by the Claude CLI itself.
+
+**** Prerequisites
+- Install the Claude CLI and make sure it is available in your PATH. See [[https://docs.anthropic.com/en/docs/claude-code/getting-started][Getting started with Claude Code]].
+- Log in with ~claude login~ at least once before using this backend.
+
+**** Basic configuration
+#+begin_src emacs-lisp
+(setq gh-copilot-chat-backend 'claude)
+#+end_src
+
+Or with ~use-package~:
+#+begin_src emacs-lisp
+(use-package gh-copilot-chat
+  :config
+  (setq gh-copilot-chat-backend 'claude))
+#+end_src
+
+**** Allowed tools
+By default, no tools are passed to the Claude CLI. You can allow specific built-in tools using the ~gh-copilot-chat-claude-allowed-tools~ variable (maps to ~--allowedTools~):
+#+begin_src emacs-lisp
+;; Example: allow bash and file editing tools
+(setq gh-copilot-chat-claude-allowed-tools "Bash,Edit,Write")
+#+end_src
+
+**** MCP servers
+When MCP servers are configured via ~mcp-hub-servers~ and enabled for a ~gh-copilot-chat~ instance (using ~gh-copilot-chat-set-mcp-servers~), they are automatically passed to the Claude CLI via ~--mcp-config~. This allows Claude to use your MCP tools directly.
+
+Example with a GitHub MCP server:
+#+begin_src emacs-lisp
+(setopt mcp-hub-servers
+  '(("github" .
+     (:command "docker"
+      :args ("run" "-i" "--rm"
+             "-e" "GITHUB_PERSONAL_ACCESS_TOKEN"
+             "ghcr.io/github/github-mcp-server")
+      :env (:GITHUB_PERSONAL_ACCESS_TOKEN "Your PAT")))))
+
+(setq gh-copilot-chat-backend 'claude)
+#+end_src
+
+Then enable the server for your instance with ~gh-copilot-chat-set-mcp-servers~.
+
+**** Session resumption
+The Claude backend automatically resumes the conversation session between prompts using ~--resume~. This means the full conversation context is preserved inside the Claude CLI process, without being re-sent to the API on each turn.
 
 ** Frontend
 Several frontends are available. You can select your favorite one by setting the ~gh-copilot-chat-frontend~ variable to ~'org~ (default), ~'markdown~ or ~'shell-maker~.
@@ -217,11 +264,13 @@ You can call ~(gh-copilot-chat-transient)~ to open transient menu. Almost all fu
 All variables can be customized using ~M-x customize-group RET gh-copilot-chat RET~.
 
 *** Backend
-- ~gh-copilot-chat-backend~ - Backend to use for API calls. Can be ~'curl~.
+- ~gh-copilot-chat-backend~ - Backend to use for API calls. Can be ~'curl~ (default) or ~'claude~.
 - ~gh-copilot-chat-curl-program~ - Path to curl executable when using curl backend.
 - ~gh-copilot-chat-curl-proxy~ - Proxy configuration for curl backend. Supports HTTP/HTTPS/SOCKS protocols.
 - ~gh-copilot-chat-curl-proxy-insecure~ - Skip SSL verification for proxy connections in curl backend.
 - ~gh-copilot-chat-curl-proxy-user-pass~ - Proxy authentication credentials for curl backend.
+- ~gh-copilot-chat-claude-program~ - Path to the ~claude~ CLI executable (default: ~"claude"~). Set this if ~claude~ is not in your PATH.
+- ~gh-copilot-chat-claude-allowed-tools~ - Comma-separated list of tools allowed for the Claude CLI (maps to ~--allowedTools~). Empty by default (no tools allowed).
 
 *** Frontend
 - ~gh-copilot-chat-frontend~ - Frontend interface to use. Can be ~'org~ (default) or ~'markdown~.


### PR DESCRIPTION
My company is now using Claude instead of Github copilot. I added a Claude backend which uses claude command line tool.
You need to be authenticated with the tool before using it in gh-copilot-chat.
